### PR TITLE
Rename chat routes to proxy for clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,24 +18,22 @@ OpenAI-compatible proxy with two privacy modes: route to local LLM or mask PII f
 src/
 ├── index.ts                 # Hono server entry
 ├── config.ts                # YAML config + Zod validation
-├── schemas/
-│   └── chat.ts              # Request/response schemas
-├── routes/                  # All route handlers
-│   ├── chat.ts              # POST /openai/v1/chat/completions
+├── routes/
+│   ├── proxy.ts             # POST /openai/v1/chat/completions
 │   ├── dashboard.tsx        # Dashboard routes + API
 │   ├── health.ts            # GET /health
 │   └── info.ts              # GET /info
-├── views/                   # JSX components
+├── views/
 │   └── dashboard/
 │       └── page.tsx         # Dashboard UI
 └── services/
-    ├── decision.ts             # Route/mask logic
-    ├── pii-detector.ts         # Presidio client
-    ├── llm-client.ts           # OpenAI/Ollama client
-    ├── masking.ts              # PII mask/unmask
-    ├── stream-transformer.ts   # SSE unmask for streaming
-    ├── language-detector.ts    # Auto language detection
-    └── logger.ts               # SQLite logging
+    ├── decision.ts          # Route/mask logic
+    ├── pii-detector.ts      # Presidio client
+    ├── llm-client.ts        # OpenAI/Ollama client
+    ├── masking.ts           # PII mask/unmask
+    ├── stream-transformer.ts # SSE unmask for streaming
+    ├── language-detector.ts # Auto language detection
+    └── logger.ts            # SQLite logging
 ```
 
 Tests are colocated (`*.test.ts`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,10 @@ import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "hono/logger";
 import { getConfig } from "./config";
-import { chatRoutes } from "./routes/chat";
 import { dashboardRoutes } from "./routes/dashboard";
 import { healthRoutes } from "./routes/health";
 import { infoRoutes } from "./routes/info";
+import { proxyRoutes } from "./routes/proxy";
 import { getLogger } from "./services/logger";
 import { getPIIDetector } from "./services/pii-detector";
 
@@ -33,7 +33,7 @@ app.use("*", logger());
 
 app.route("/", healthRoutes);
 app.route("/", infoRoutes);
-app.route("/openai/v1", chatRoutes);
+app.route("/openai/v1", proxyRoutes);
 
 if (config.dashboard.enabled) {
   app.route("/dashboard", dashboardRoutes);

--- a/src/routes/proxy.test.ts
+++ b/src/routes/proxy.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { Hono } from "hono";
-import { chatRoutes } from "./chat";
+import { proxyRoutes } from "./proxy";
 
 const app = new Hono();
-app.route("/openai/v1", chatRoutes);
+app.route("/openai/v1", proxyRoutes);
 
 describe("POST /openai/v1/chat/completions", () => {
   test("returns 400 for missing messages", async () => {

--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -30,7 +30,7 @@ const ChatCompletionSchema = z
   })
   .passthrough();
 
-export const chatRoutes = new Hono();
+export const proxyRoutes = new Hono();
 
 /**
  * Type guard for MaskDecision
@@ -39,7 +39,7 @@ function isMaskDecision(decision: RoutingDecision): decision is MaskDecision {
   return decision.mode === "mask";
 }
 
-chatRoutes.get("/models", (c) => {
+proxyRoutes.get("/models", (c) => {
   const { upstream } = getRouter().getProvidersInfo();
 
   return proxy(`${upstream.baseUrl}/models`, {
@@ -52,7 +52,7 @@ chatRoutes.get("/models", (c) => {
 /**
  * POST /v1/chat/completions - OpenAI-compatible chat completion endpoint
  */
-chatRoutes.post(
+proxyRoutes.post(
   "/chat/completions",
   zValidator("json", ChatCompletionSchema, (result, c) => {
     if (!result.success) {


### PR DESCRIPTION
## Summary
- Rename `chat.ts` → `proxy.ts` to better reflect purpose (LLM proxy routing)
- Update CLAUDE.md architecture to match actual file structure

## Test plan
- [x] All 50 tests pass
- [x] TypeScript and Biome checks pass
- [x] Manual test: `/health` and `/info` endpoints work