### PR TITLE
fix: support developer and function roles for GPT-5.x compatibility

### DIFF
--- a/src/routes/proxy.test.ts
+++ b/src/routes/proxy.test.ts
@@ -41,6 +41,24 @@ describe("POST /openai/v1/chat/completions", () => {
 
     expect(res.status).toBe(400);
   });
+
+  test("accepts developer role (GPT-5.x compatibility)", async () => {
+    const res = await app.request("/openai/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({
+        messages: [
+          { role: "developer", content: "You are a helpful assistant" },
+          { role: "user", content: "Hello" },
+        ],
+        model: "gpt-5.2",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    // Should not be 400 (validation passed)
+    // Will be 401/502 without API key, but that's fine - we're testing validation
+    expect(res.status).not.toBe(400);
+  });
 });
 
 describe("GET /openai/v1/models", () => {

--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -30,7 +30,7 @@ const ChatCompletionSchema = z
       .array(
         z
           .object({
-            role: z.enum(["system", "user", "assistant", "tool"]),
+            role: z.enum(["system", "developer", "user", "assistant", "tool", "function"]),
             content: z.union([z.string(), z.array(z.any()), z.null()]).optional(),
           })
           .passthrough(), // Allow additional fields like name, tool_calls, etc.

--- a/src/services/llm-client.ts
+++ b/src/services/llm-client.ts
@@ -6,7 +6,7 @@ import type { MessageContent } from "../utils/content";
  * Supports both text-only (content: string) and multimodal (content: array) formats
  */
 export interface ChatMessage {
-  role: "system" | "user" | "assistant";
+  role: "system" | "developer" | "user" | "assistant";
   content: MessageContent;
 }
 


### PR DESCRIPTION
## Summary
- Add `developer` role support (used by GPT-5.x instead of `system`)
- Add `function` role support (legacy compatibility)
- Add test for developer role validation

## Context
GPT-5.x models introduced the `developer` role as a replacement for `system`. Requests with this role were rejected with 400 "Invalid request body".

Fixes #22