### PR TITLE
Exclude test files from secret scanning

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,4 @@
+# Exclude test files from secret scanning
+# Test files contain intentional fake secrets for testing secret detection
+paths-ignore:
+  - "src/**/*.test.ts"


### PR DESCRIPTION
## Summary
- Add `.github/secret_scanning.yml` to exclude test files from GitHub secret scanning
- Prevents false positive alerts for intentional fake secrets in test fixtures

## Context
GitHub Secret Scanning flagged MongoDB connection strings in `src/secrets/detect.test.ts` as "Public leak". These are intentional test fixtures for testing PasteGuard's secret detection functionality.

Fixes #4, #3 (secret scanning alerts)

## Test plan
- [ ] Verify existing secret scanning alerts can be closed as "Used in tests"
- [ ] Confirm new test secrets don't trigger alerts