### PR TITLE
Add prebuilt Docker images with GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME_APP: ${{ github.repository }}
+  IMAGE_NAME_PRESIDIO: ${{ github.repository }}-presidio
+
+jobs:
+  build-app:
+    name: Build App
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_APP }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-presidio:
+    name: Build Presidio (${{ matrix.tag }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - tag: en
+            languages: "en"
+            latest: true
+          - tag: eu
+            languages: "en,de,es,fr,it,nl,pl,pt,ro"
+            latest: false
+    steps:
+      - name: Free disk space
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./presidio
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: LANGUAGES=${{ matrix.languages }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PRESIDIO }}:${{ matrix.tag }}
+            ${{ matrix.latest && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME_PRESIDIO) || '' }}
+          cache-from: type=gha,scope=presidio-${{ matrix.tag }}
+          cache-to: type=gha,mode=max,scope=presidio-${{ matrix.tag }}

--- a/README.md
+++ b/README.md
@@ -19,14 +19,7 @@
 
 <br/>
 
-<p align="center">
-  <img src="assets/demo.gif" width="720" alt="PasteGuard Demo">
-</p>
-<p align="center">
-  <em>Your App → PasteGuard → OpenAI — PII never reaches external servers</em>
-</p>
-
-<br/>
+<img src="assets/dashboard.png" width="100%" alt="PasteGuard Dashboard">
 
 ## What is PasteGuard?
 
@@ -81,10 +74,21 @@ Point your app to `http://localhost:3000/openai/v1` instead of `https://api.open
 
 Dashboard: [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
 
-<img src="assets/dashboard.png" width="100%" alt="PasteGuard Dashboard">
-<p><em>Every request logged with masked content preview</em></p>
+### Multiple Languages
 
-For multiple languages, configuration options, and more: **[Read the docs →](https://pasteguard.com/docs/quickstart)**
+Default uses English only. For European languages (German, Spanish, French, Italian, Dutch, Polish, Portuguese, Romanian):
+
+```bash
+PRESIDIO_TAG=eu docker compose up -d
+```
+
+For other languages, build locally:
+
+```bash
+LANGUAGES=en,de,ja docker compose -f docker-compose.build.yml up -d --build
+```
+
+For configuration options and more: **[Read the docs →](https://pasteguard.com/docs/quickstart)**
 
 ## Integrations
 
@@ -118,9 +122,6 @@ Works with any OpenAI-compatible tool:
 - GitHub tokens
 - JWT tokens
 - Bearer tokens
-- Env passwords
-- Env secrets
-- Connection strings
 
 ## Tech Stack
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   pasteguard:
+    image: ghcr.io/sgasser/pasteguard:latest
     build: .
     ports:
       - "3000:3000"
@@ -16,14 +17,10 @@ services:
     restart: unless-stopped
 
   presidio-analyzer:
+    image: ghcr.io/sgasser/pasteguard-presidio:${PRESIDIO_TAG:-en}
     build:
       context: ./presidio
       args:
-        # Languages to install for PII detection
-        # Available: ca, zh, hr, da, nl, en, fi, fr, de, el, it, ja, ko,
-        #            lt, mk, nb, pl, pt, ro, ru, sl, es, sv, uk
-        # See presidio/languages.yaml for full list
-        # Example: LANGUAGES=en,de,fr docker-compose build
         LANGUAGES: ${LANGUAGES:-en}
     ports:
       - "5002:3000"

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,0 +1,113 @@
+---
+title: Installation
+description: Docker images and deployment options
+---
+
+# Installation
+
+PasteGuard provides prebuilt Docker images for quick deployment. No build step required.
+
+## Docker Images
+
+PasteGuard uses two containers that work together:
+
+| Image | Purpose | Size |
+|-------|---------|------|
+| `ghcr.io/sgasser/pasteguard` | Proxy server, dashboard, API | ~100MB |
+| `ghcr.io/sgasser/pasteguard-presidio` | PII detection (Python + spaCy models) | 1.5-3GB |
+
+The proxy receives requests, sends text to Presidio for PII scanning, masks detected entities, and forwards to the upstream LLM.
+
+### Presidio Language Tags
+
+| Tag | Languages | Size | Use Case |
+|-----|-----------|------|----------|
+| `en` / `latest` | English | ~1.5GB | Default, English-only teams |
+| `eu` | en, de, es, fr, it, nl, pl, pt, ro | ~3GB | European businesses |
+
+## Quick Start
+
+```bash
+git clone https://github.com/sgasser/pasteguard.git
+cd pasteguard
+cp config.example.yaml config.yaml
+docker compose up -d
+```
+
+This uses the `en` (English-only) image by default.
+
+## European Languages
+
+For German, Spanish, French, Italian, Dutch, Polish, Portuguese, and Romanian support:
+
+```bash
+PRESIDIO_TAG=eu docker compose up -d
+```
+
+Update your `config.yaml` to enable the languages you need:
+
+```yaml
+pii_detection:
+  languages:
+    - en
+    - de
+    - fr
+    - es
+    - it
+```
+
+## Custom Language Builds
+
+For languages not included in prebuilt images (Nordic, Asian, Eastern European), build locally:
+
+```bash
+# Example: English + German + Japanese
+LANGUAGES=en,de,ja docker compose up -d --build
+```
+
+### Available Languages (24)
+
+| Code | Language | Code | Language |
+|------|----------|------|----------|
+| `en` | English | `ja` | Japanese |
+| `de` | German | `ko` | Korean |
+| `fr` | French | `zh` | Chinese |
+| `es` | Spanish | `sv` | Swedish |
+| `it` | Italian | `da` | Danish |
+| `nl` | Dutch | `nb` | Norwegian |
+| `pt` | Portuguese | `fi` | Finnish |
+| `pl` | Polish | `el` | Greek |
+| `ru` | Russian | `ro` | Romanian |
+| `uk` | Ukrainian | `hr` | Croatian |
+| `ca` | Catalan | `sl` | Slovenian |
+| `lt` | Lithuanian | `mk` | Macedonian |
+
+See `presidio/languages.yaml` for details.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PRESIDIO_TAG` | `en` | Presidio image tag (`en`, `eu`) |
+| `LANGUAGES` | `en` | Languages for local build |
+
+## Verify Installation
+
+```bash
+# Check health
+curl http://localhost:3000/health
+
+# Check mode and languages
+curl http://localhost:3000/info
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Make your first request
+  </Card>
+  <Card title="Configuration" icon="gear" href="/configuration/overview">
+    Customize PasteGuard
+  </Card>
+</CardGroup>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -34,7 +34,7 @@
   "navigation": [
     {
       "group": "Getting Started",
-      "pages": ["introduction", "quickstart", "integrations"]
+      "pages": ["introduction", "quickstart", "installation", "integrations"]
     },
     {
       "group": "Concepts",

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -16,26 +16,9 @@ docker compose up -d
 
 PasteGuard runs on `http://localhost:3000`. Dashboard at `http://localhost:3000/dashboard`.
 
-<Accordion title="Multiple Languages">
-By default, only English is installed (~1.5GB image). To add more languages:
-
-```bash
-# English + German + French (~2.5GB)
-LANGUAGES=en,de,fr docker compose up -d --build
-```
-
-Update `config.yaml` to match:
-
-```yaml
-pii_detection:
-  languages:
-    - en
-    - de
-    - fr
-```
-
-See [PII Detection Config](/configuration/pii-detection) for all 24 available languages.
-</Accordion>
+<Note>
+For European languages (German, French, Spanish, etc.), see [Installation](/installation#european-languages).
+</Note>
 
 ## 2. Make a Request
 
@@ -119,6 +102,9 @@ Open `http://localhost:3000/dashboard` in your browser to see:
 ## What's Next?
 
 <CardGroup cols={2}>
+  <Card title="Installation" icon="download" href="/installation">
+    Docker images and language options
+  </Card>
   <Card title="Mask Mode" icon="eye-slash" href="/concepts/mask-mode">
     How PII masking works
   </Card>
@@ -127,8 +113,5 @@ Open `http://localhost:3000/dashboard` in your browser to see:
   </Card>
   <Card title="Configuration" icon="gear" href="/configuration/overview">
     Customize detection and providers
-  </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/chat-completions">
-    Explore the API
   </Card>
 </CardGroup>

--- a/presidio/Dockerfile
+++ b/presidio/Dockerfile
@@ -35,6 +35,21 @@ RUN python generate-configs.py \
 # =============================================================================
 FROM mcr.microsoft.com/presidio-analyzer:latest
 
+# Pass LANGUAGES to this stage for conditional Rust installation
+ARG LANGUAGES
+
+# Install Rust compiler only if Japanese (ja) is included
+# Japanese requires sudachipy which needs Rust to compile
+RUN if echo "${LANGUAGES}" | grep -q "ja"; then \
+        apt-get update && apt-get install -y --no-install-recommends \
+            curl \
+            build-essential \
+        && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # Copy generated configuration files
 COPY --from=generator /output/nlp-config.yaml /usr/bin/presidio_analyzer/conf/default.yaml
 COPY --from=generator /output/recognizers-config.yaml /usr/bin/presidio_analyzer/conf/default_recognizers.yaml

--- a/presidio/languages.yaml
+++ b/presidio/languages.yaml
@@ -1,10 +1,7 @@
 # PasteGuard Language Registry
-# All 24 spaCy languages with trained pipelines
+# 24 spaCy languages with large models for accurate PII detection
 #
-# Usage: Set LANGUAGES build arg to select which to install
-#   LANGUAGES=en,de docker-compose build
-#
-# To add a custom language, add an entry here with model name
+# Usage: LANGUAGES=en,de docker compose build
 
 spacy_version: "3.8.0"
 
@@ -16,31 +13,31 @@ languages:
   # Catalan
   ca:
     name: Catalan
-    model: ca_core_news_md
+    model: ca_core_news_lg
     phone_context: [telèfon, número, mòbil, trucada, trucar]
 
   # Chinese
   zh:
     name: Chinese
-    model: zh_core_web_md
+    model: zh_core_web_lg
     phone_context: [电话, 手机, 号码, 打电话, 电话号码, 手机号码]
 
   # Croatian
   hr:
     name: Croatian
-    model: hr_core_news_md
+    model: hr_core_news_lg
     phone_context: [telefon, broj, mobitel, poziv, nazovi, zvati]
 
   # Danish
   da:
     name: Danish
-    model: da_core_news_md
+    model: da_core_news_lg
     phone_context: [telefon, nummer, mobil, mobiltelefon, opkald, ringe]
 
   # Dutch
   nl:
     name: Dutch
-    model: nl_core_news_md
+    model: nl_core_news_lg
     phone_context: [telefoon, nummer, mobiel, mobieltje, GSM, bellen]
 
   # English (Presidio defaults)
@@ -52,13 +49,13 @@ languages:
   # Finnish
   fi:
     name: Finnish
-    model: fi_core_news_md
+    model: fi_core_news_lg
     phone_context: [puhelin, numero, kännykkä, matkapuhelin, soittaa, puhelinnumero]
 
   # French
   fr:
     name: French
-    model: fr_core_news_md
+    model: fr_core_news_lg
     phone_context: [téléphone, numéro, portable, mobile, appeler, tél]
 
   # German
@@ -70,89 +67,89 @@ languages:
   # Greek
   el:
     name: Greek
-    model: el_core_news_md
+    model: el_core_news_lg
     phone_context: [τηλέφωνο, αριθμός, κινητό, κλήση, τηλεφωνώ, καλώ]
 
   # Italian
   it:
     name: Italian
-    model: it_core_news_md
+    model: it_core_news_lg
     phone_context: [telefono, numero, cellulare, telefonino, chiamare, chiamata]
 
   # Japanese
   ja:
     name: Japanese
-    model: ja_core_news_md
+    model: ja_core_news_lg
     phone_context: [電話, 携帯, 番号, スマホ, ケータイ, 電話番号]
 
   # Korean
   ko:
     name: Korean
-    model: ko_core_news_md
+    model: ko_core_news_lg
     phone_context: [전화, 휴대폰, 핸드폰, 번호, 전화번호, 통화]
 
   # Lithuanian
   lt:
     name: Lithuanian
-    model: lt_core_news_md
+    model: lt_core_news_lg
     phone_context: [telefonas, numeris, mobilusis, skambutis, skambinti]
 
   # Macedonian
   mk:
     name: Macedonian
-    model: mk_core_news_md
+    model: mk_core_news_lg
     phone_context: [телефон, број, мобилен, повик, звони]
 
   # Norwegian Bokmål
   nb:
     name: Norwegian
-    model: nb_core_news_md
+    model: nb_core_news_lg
     phone_context: [telefon, nummer, mobil, mobiltelefon, samtale, ringe]
 
   # Polish
   pl:
     name: Polish
-    model: pl_core_news_md
+    model: pl_core_news_lg
     phone_context: [telefon, numer, komórka, komórkowy, dzwoń, zadzwoń]
 
   # Portuguese
   pt:
     name: Portuguese
-    model: pt_core_news_md
+    model: pt_core_news_lg
     phone_context: [telefone, número, celular, telemóvel, ligar, telefonar]
 
   # Romanian
   ro:
     name: Romanian
-    model: ro_core_news_md
+    model: ro_core_news_lg
     phone_context: [telefon, număr, mobil, apel, suna]
 
   # Russian
   ru:
     name: Russian
-    model: ru_core_news_md
+    model: ru_core_news_lg
     phone_context: [телефон, номер, мобильник, мобила, сотовый, звонок]
 
   # Slovenian
   sl:
     name: Slovenian
-    model: sl_core_news_md
+    model: sl_core_news_lg
     phone_context: [telefon, številka, mobilnik, mobilec, klic, pokliči]
 
   # Spanish
   es:
     name: Spanish
-    model: es_core_news_md
+    model: es_core_news_lg
     phone_context: [teléfono, número, móvil, celular, llamar, llamada]
 
   # Swedish
   sv:
     name: Swedish
-    model: sv_core_news_md
+    model: sv_core_news_lg
     phone_context: [telefon, nummer, mobil, mobiltelefon, samtal, ringa]
 
   # Ukrainian
   uk:
     name: Ukrainian
-    model: uk_core_news_md
+    model: uk_core_news_lg
     phone_context: [телефон, номер, мобільний, мобілка, дзвінок, дзвони]

--- a/presidio/scripts/generate-configs.py
+++ b/presidio/scripts/generate-configs.py
@@ -57,11 +57,25 @@ def generate_nlp_config(languages: list[str], registry: dict) -> dict:
         "models": models,
         "ner_model_configuration": {
             "model_to_presidio_entity_mapping": {
+                # Standard labels (most languages)
                 "PER": "PERSON",
                 "PERSON": "PERSON",
                 "LOC": "LOCATION",
                 "GPE": "LOCATION",
                 "ORG": "ORGANIZATION",
+                # Polish (NKJP corpus)
+                "persName": "PERSON",
+                "placeName": "LOCATION",
+                "geogName": "LOCATION",
+                "orgName": "ORGANIZATION",
+                # Korean
+                "PS": "PERSON",
+                "LC": "LOCATION",
+                "OG": "ORGANIZATION",
+                # Swedish
+                "PRS": "PERSON",
+                # Norwegian
+                "GPE_LOC": "LOCATION",
             },
             "low_confidence_score_multiplier": 0.4,
             "low_score_entity_names": ["ORG"],
@@ -148,7 +162,8 @@ def generate_install_script(languages: list[str], registry: dict) -> str:
         model = registry["languages"][lang]["model"]
         url = f"https://github.com/explosion/spacy-models/releases/download/{model}-{version}/{model}-{version}-py3-none-any.whl"
         lines.append(f'echo "Installing {model} for {lang}..."')
-        lines.append(f"pip install --no-cache-dir {url}")
+        # Use poetry run pip to install in the correct virtual environment
+        lines.append(f"poetry run pip install --no-cache-dir {url}")
         lines.append("")
 
     lines.append('echo "All models installed successfully"')


### PR DESCRIPTION
## Summary

- Add release.yml workflow triggered on version tags (v*)
- Publish to ghcr.io: `pasteguard` and `pasteguard-presidio`
- Presidio tags: `en` (default), `eu` (9 European languages)
- Add entity mappings for non-standard spaCy labels (Korean, Swedish, Norwegian, Polish)
- Make Rust compiler conditional (only for Japanese)
- Consolidate docker-compose files into single file
- Add installation.mdx with Docker image documentation

## Docker Images

| Image | Description |
|-------|-------------|
| `ghcr.io/sgasser/pasteguard:latest` | PasteGuard proxy |
| `ghcr.io/sgasser/pasteguard-presidio:en` | English only (default) |
| `ghcr.io/sgasser/pasteguard-presidio:eu` | European languages (en,de,es,fr,it,nl,pl,pt,ro) |

## Test plan

- [ ] Create test tag and verify workflow runs
- [ ] Pull and test both presidio images
- [ ] Verify dashboard works with prebuilt images