### PR TITLE
ci(workflow): add GHCR publishing with multi-language Presidio support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g., v2.0.0). Leave empty for auto-increment."
+        required: false
+        type: string
 
 jobs:
   test:
@@ -30,12 +36,163 @@ jobs:
       - name: Run tests
         run: bun test
 
-  docker-build:
+  docker-build-test:
     name: Docker Build Test
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test Docker build
+      - name: Test Docker build (pasteguard)
         run: docker build -t pasteguard:test .
+
+      - name: Test Docker build (presidio)
+        run: docker build -t presidio:test ./presidio
+
+  # Only create/push tags and images on main branch after tests pass
+  create-tag:
+    name: Create Version Tag
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    needs: [test, docker-build-test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.manual_version.outputs.tag || steps.tagger.outputs.tag }}
+      new_tag: ${{ steps.manual_version.outputs.tag || steps.tagger.outputs.new_tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for tagging
+
+      - name: Use manual version if provided
+        id: manual_version
+        if: github.event.inputs.version != ''
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          # Ensure version starts with 'v'
+          if [[ ! $VERSION == v* ]]; then
+            VERSION="v$VERSION"
+          fi
+          echo "tag=$VERSION" >> $GITHUB_OUTPUT
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          echo "Created manual tag: $VERSION"
+
+      - name: Auto-increment version tag
+        id: tagger
+        if: github.event.inputs.version == ''
+        uses: anothrNick/github-tag-action@1.75.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_PREFIX: v
+          DEFAULT_BUMP: patch
+
+      - name: Log version info
+        run: |
+          if [[ -n "${{ steps.manual_version.outputs.tag }}" ]]; then
+            echo "Using manual version: ${{ steps.manual_version.outputs.tag }}"
+          else
+            echo "Auto-created tag: ${{ steps.tagger.outputs.new_tag }}"
+            echo "Previous tag: ${{ steps.tagger.outputs.tag }}"
+          fi
+
+  build-and-push-pasteguard:
+    name: Build & Push PasteGuard
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    needs: create-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push PasteGuard image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ needs.create-tag.outputs.new_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-and-push-presidio:
+    name: Build & Push Presidio (${{ matrix.languages }})
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    needs: create-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - languages: "en"
+            tag_suffix: "-en"
+            variant: "en"
+          - languages: "en,de"
+            tag_suffix: "-en-de"
+            variant: "de"
+          - languages: "en,fr"
+            tag_suffix: "-en-fr"
+            variant: "fr"
+          - languages: "en,es"
+            tag_suffix: "-en-es"
+            variant: "es"
+          - languages: "en,zh"
+            tag_suffix: "-en-zh"
+            variant: "zh"
+          - languages: "en,ja"
+            tag_suffix: "-en-ja"
+            variant: "ja"
+          - languages: "en,ko"
+            tag_suffix: "-en-ko"
+            variant: "ko"
+          - languages: "en,ru"
+            tag_suffix: "-en-ru"
+            variant: "ru"
+          - languages: "en,de,fr,es,ja,ko,ru,zh"
+            tag_suffix: "-en-multi"
+            variant: "multi"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Presidio image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./presidio
+          push: true
+          build-args: |
+            LANGUAGES=${{ matrix.languages }}
+          tags: |
+            ghcr.io/${{ github.repository }}-presidio:${{ needs.create-tag.outputs.new_tag }}${{ matrix.tag_suffix }}
+            ghcr.io/${{ github.repository }}-presidio:latest${{ matrix.tag_suffix }}
+            ${{ matrix.variant == 'en' && format('ghcr.io/{0}-presidio:latest', github.repository) || '' }}
+          cache-from: type=gha,scope=presidio-${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=presidio-${{ matrix.variant }}

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,0 +1,36 @@
+services:
+  pasteguard:
+    build: .
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    environment:
+      - PRESIDIO_URL=http://presidio-analyzer:3000
+    volumes:
+      - ./config.yaml:/app/config.yaml:ro
+      - ./data:/app/data
+    depends_on:
+      presidio-analyzer:
+        condition: service_healthy
+    restart: unless-stopped
+
+  presidio-analyzer:
+    build:
+      context: ./presidio
+      args:
+        # Languages to install for PII detection
+        # Available: ca, zh, hr, da, nl, en, fi, fr, de, el, it, ja, ko,
+        #            lt, mk, nb, pl, pt, ro, ru, sl, es, sv, uk
+        # See presidio/languages.yaml for full list
+        # Example: LANGUAGES=en,de,fr docker-compose build
+        LANGUAGES: ${LANGUAGES:-en}
+    ports:
+      - "5002:3000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:3000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pasteguard:
-    build: .
+    image: ghcr.io/sgasser/pasteguard:latest
     ports:
       - "3000:3000"
     env_file:
@@ -15,20 +15,34 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # Presidio Analyzer - PII detection service
+  # Multiple language variants are available. Choose the one that matches your needs:
+  #   - latest-en       : English only (smallest, fastest)
+  #   - latest-en-de    : English + German
+  #   - latest-en-fr    : English + French
+  #   - latest-en-es    : English + Spanish
+  #   - latest-en-zh    : English + Chinese
+  #   - latest-en-ja    : English + Japanese
+  #   - latest-en-ko    : English + Korean
+  #   - latest-en-ru    : English + Russian
+  #   - latest-en-multi : English + German, French, Spanish, Japanese, Korean, Russian, Chinese (largest)
+  #
+  # If you need to use a different language variant,
+  # you can build the image yourself using the docker-compose-build.yml file.
+  #
+  # To change the language variant, modify the image tag below:
   presidio-analyzer:
-    build:
-      context: ./presidio
-      args:
-        # Languages to install for PII detection
-        # Available: ca, zh, hr, da, nl, en, fi, fr, de, el, it, ja, ko,
-        #            lt, mk, nb, pl, pt, ro, ru, sl, es, sv, uk
-        # See presidio/languages.yaml for full list
-        # Example: LANGUAGES=en,de,fr docker-compose build
-        LANGUAGES: ${LANGUAGES:-en}
+    image: ghcr.io/sgasser/pasteguard-presidio:latest-en
     ports:
       - "5002:3000"
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:3000/health')"]
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:3000/health')",
+        ]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Extends CI pipeline to publish Docker images when changes land on main or when manually triggered via workflow_dispatch with optional version input. The create-tag job handles version bumping automatically using semantic versioning conventions.

Presidio analyzer now ships in 9 language variants through matrix strategy, from single-language (en) to full multilingual bundles. Default docker-compose configuration consumes published images from GHCR while docker-compose-build.yml offers the original source-based workflow for custom builds.

@sgasser as per our discussion on Reddit, here's the PR for the automated image builds. This should make adoption a lot easier for everyone on /r/selfhosted!