### PR TITLE
fix: use [[]] delimiters for placeholders to prevent HTML encoding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Works with OpenAI, Azure, and any OpenAI-compatible API. Just change one URL.
 You send:     "Write a follow-up email to Dr. Sarah Chen (sarah.chen@hospital.org)
                about next week's project meeting"
 
-LLM receives: "Write a follow-up email to <PERSON_1> (<EMAIL_ADDRESS_1>)
+LLM receives: "Write a follow-up email to [[PERSON_1]] ([[EMAIL_ADDRESS_1]])
                about next week's project meeting"
 
-LLM responds: "Dear <PERSON_1>, Following up on our discussion..."
+LLM responds: "Dear [[PERSON_1]], Following up on our discussion..."
 
 You receive:  "Dear Dr. Sarah Chen, Following up on our discussion..."
 ```

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -139,10 +139,6 @@ secrets_detection:
   # The 200KB default covers typical use cases
   max_scan_chars: 200000
 
-  # Placeholder format for redaction (only used if action: redact)
-  # {N} will be replaced with type and sequential number (e.g., API_KEY_OPENAI_1)
-  redact_placeholder: "<SECRET_REDACTED_{N}>"
-
   # Log detected secret types (never logs secret content)
   # Even if logging.log_content is true, secret content is never logged
   log_detected_types: true

--- a/docs/api-reference/dashboard-api.mdx
+++ b/docs/api-reference/dashboard-api.mdx
@@ -49,7 +49,7 @@ curl "http://localhost:3000/dashboard/api/logs?limit=100&offset=0"
       "language": "en",
       "language_fallback": false,
       "detected_language": "en",
-      "masked_content": "Hello <EMAIL_ADDRESS_1>",
+      "masked_content": "Hello [[EMAIL_ADDRESS_1]]",
       "secrets_detected": 0,
       "secrets_types": null
     }

--- a/docs/concepts/mask-mode.mdx
+++ b/docs/concepts/mask-mode.mdx
@@ -17,10 +17,10 @@ Mask mode replaces PII with placeholders before sending to your LLM provider. Th
     PasteGuard finds: `Dr. Sarah Chen` (PERSON), `sarah.chen@hospital.org` (EMAIL)
   </Step>
   <Step title="Masked request sent">
-    Provider receives: `"Write a follow-up email to <PERSON_1> (<EMAIL_ADDRESS_1>)"`
+    Provider receives: `"Write a follow-up email to [[PERSON_1]] ([[EMAIL_ADDRESS_1]])"`
   </Step>
   <Step title="Response masked">
-    Provider responds: `"Dear <PERSON_1>, Following up on our discussion..."`
+    Provider responds: `"Dear [[PERSON_1]], Following up on our discussion..."`
   </Step>
   <Step title="Response unmasked">
     You receive: `"Dear Dr. Sarah Chen, Following up on our discussion..."`

--- a/docs/configuration/logging.mdx
+++ b/docs/configuration/logging.mdx
@@ -87,4 +87,4 @@ Only metadata (timestamps, models, PII detected) is logged.
 
 - Secret content is **never** logged, even if `log_content: true`
 - Only secret types are logged if `log_detected_types: true`
-- Masked content shows placeholders like `<EMAIL_ADDRESS_1>`, not real PII
+- Masked content shows placeholders like `[[EMAIL_ADDRESS_1]]`, not real PII

--- a/docs/configuration/secrets-detection.mdx
+++ b/docs/configuration/secrets-detection.mdx
@@ -25,7 +25,6 @@ secrets_detection:
 | `entities` | Private keys | Secret types to detect |
 | `max_scan_chars` | `200000` | Max characters to scan (0 = unlimited) |
 | `log_detected_types` | `true` | Log detected types (never logs content) |
-| `redact_placeholder` | `<SECRET_REDACTED_{N}>` | Placeholder format for redaction |
 
 ## Actions
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -35,11 +35,11 @@ Two privacy modes:
     ```
   </Step>
   <Step title="PasteGuard masks PII">
-    Detected: `Dr. Sarah Chen` → `<PERSON_1>`, `sarah.chen@hospital.org` → `<EMAIL_ADDRESS_1>`
+    Detected: `Dr. Sarah Chen` → `[[PERSON_1]]`, `sarah.chen@hospital.org` → `[[EMAIL_ADDRESS_1]]`
   </Step>
   <Step title="OpenAI receives">
     ```
-    Write a follow-up email to <PERSON_1> (<EMAIL_ADDRESS_1>)
+    Write a follow-up email to [[PERSON_1]] ([[EMAIL_ADDRESS_1]])
     ```
   </Step>
   <Step title="You get the response (unmasked)">

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,7 +111,6 @@ const SecretsDetectionSchema = z.object({
   action: z.enum(["block", "redact", "route_local"]).default("redact"),
   entities: z.array(z.enum(SecretEntityTypes)).default(["OPENSSH_PRIVATE_KEY", "PEM_PRIVATE_KEY"]),
   max_scan_chars: z.coerce.number().int().min(0).default(200000),
-  redact_placeholder: z.string().default("<SECRET_REDACTED_{N}>"),
   log_detected_types: z.boolean().default(true),
 });
 

--- a/src/constants/placeholders.test.ts
+++ b/src/constants/placeholders.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  findPartialPlaceholderStart,
+  generatePlaceholder,
+  generateSecretPlaceholder,
+  PII_PLACEHOLDER_FORMAT,
+  PLACEHOLDER_DELIMITERS,
+  SECRET_PLACEHOLDER_FORMAT,
+} from "./placeholders";
+
+describe("placeholder constants", () => {
+  test("delimiters are correct", () => {
+    expect(PLACEHOLDER_DELIMITERS.start).toBe("[[");
+    expect(PLACEHOLDER_DELIMITERS.end).toBe("]]");
+  });
+
+  test("PII format uses correct delimiters", () => {
+    expect(PII_PLACEHOLDER_FORMAT).toContain(PLACEHOLDER_DELIMITERS.start);
+    expect(PII_PLACEHOLDER_FORMAT).toContain(PLACEHOLDER_DELIMITERS.end);
+    expect(PII_PLACEHOLDER_FORMAT).toBe("[[{TYPE}_{N}]]");
+  });
+
+  test("secret format uses correct delimiters", () => {
+    expect(SECRET_PLACEHOLDER_FORMAT).toContain(PLACEHOLDER_DELIMITERS.start);
+    expect(SECRET_PLACEHOLDER_FORMAT).toContain(PLACEHOLDER_DELIMITERS.end);
+    expect(SECRET_PLACEHOLDER_FORMAT).toBe("[[SECRET_REDACTED_{N}]]");
+  });
+});
+
+describe("generatePlaceholder", () => {
+  test("generates PII placeholder", () => {
+    const result = generatePlaceholder(PII_PLACEHOLDER_FORMAT, "PERSON", 1);
+    expect(result).toBe("[[PERSON_1]]");
+  });
+
+  test("generates placeholder with different type and count", () => {
+    const result = generatePlaceholder(PII_PLACEHOLDER_FORMAT, "EMAIL_ADDRESS", 3);
+    expect(result).toBe("[[EMAIL_ADDRESS_3]]");
+  });
+});
+
+describe("generateSecretPlaceholder", () => {
+  test("generates secret placeholder", () => {
+    const result = generateSecretPlaceholder("API_KEY_OPENAI", 1);
+    expect(result).toBe("[[SECRET_REDACTED_API_KEY_OPENAI_1]]");
+  });
+
+  test("generates secret placeholder with different type and count", () => {
+    const result = generateSecretPlaceholder("PEM_PRIVATE_KEY", 2);
+    expect(result).toBe("[[SECRET_REDACTED_PEM_PRIVATE_KEY_2]]");
+  });
+});
+
+describe("findPartialPlaceholderStart", () => {
+  test("returns -1 for empty string", () => {
+    expect(findPartialPlaceholderStart("")).toBe(-1);
+  });
+
+  test("returns -1 when no placeholder pattern", () => {
+    expect(findPartialPlaceholderStart("Hello world")).toBe(-1);
+  });
+
+  test("returns -1 when placeholder is complete", () => {
+    expect(findPartialPlaceholderStart("Hello [[PERSON_1]] world")).toBe(-1);
+  });
+
+  test("returns -1 when multiple complete placeholders", () => {
+    expect(findPartialPlaceholderStart("[[PERSON_1]] and [[EMAIL_1]]")).toBe(-1);
+  });
+
+  test("returns position of partial placeholder at end", () => {
+    const text = "Hello [[PERSON";
+    expect(findPartialPlaceholderStart(text)).toBe(6);
+  });
+
+  test("returns position of partial placeholder with complete one before", () => {
+    const text = "[[PERSON_1]] Hello [[EMAIL";
+    expect(findPartialPlaceholderStart(text)).toBe(19);
+  });
+
+  test("handles just opening delimiter", () => {
+    const text = "Hello [[";
+    expect(findPartialPlaceholderStart(text)).toBe(6);
+  });
+
+  test("handles text ending with single bracket", () => {
+    // Single [ is not a placeholder start, so should return -1
+    expect(findPartialPlaceholderStart("Hello [")).toBe(-1);
+  });
+});

--- a/src/constants/placeholders.ts
+++ b/src/constants/placeholders.ts
@@ -1,0 +1,54 @@
+/**
+ * Placeholder constants for PII masking and secrets redaction
+ * Single source of truth for all placeholder-related logic
+ */
+
+export const PLACEHOLDER_DELIMITERS = {
+  start: "[[",
+  end: "]]",
+} as const;
+
+/** PII placeholder format: [[TYPE_N]] e.g. [[PERSON_1]], [[EMAIL_ADDRESS_2]] */
+export const PII_PLACEHOLDER_FORMAT = "[[{TYPE}_{N}]]";
+
+/** Secrets placeholder format: [[SECRET_REDACTED_TYPE_N]] e.g. [[SECRET_REDACTED_API_KEY_OPENAI_1]] */
+export const SECRET_PLACEHOLDER_FORMAT = "[[SECRET_REDACTED_{N}]]";
+
+/**
+ * Generates a placeholder string from the format
+ */
+export function generatePlaceholder(format: string, type: string, count: number): string {
+  return format.replace("{TYPE}", type).replace("{N}", String(count));
+}
+
+/**
+ * Generates a secret placeholder string
+ * {N} is replaced with TYPE_COUNT e.g. API_KEY_OPENAI_1
+ */
+export function generateSecretPlaceholder(type: string, count: number): string {
+  return SECRET_PLACEHOLDER_FORMAT.replace("{N}", `${type}_${count}`);
+}
+
+/**
+ * Streaming buffer helper - finds safe position to process text
+ * that may contain partial placeholders
+ *
+ * Returns the position where it's safe to split, or -1 if entire string is safe
+ */
+export function findPartialPlaceholderStart(text: string): number {
+  const placeholderStart = text.lastIndexOf(PLACEHOLDER_DELIMITERS.start);
+
+  if (placeholderStart === -1) {
+    return -1; // No potential placeholder, entire string is safe
+  }
+
+  // Check if there's a complete placeholder after the last [[
+  const afterStart = text.slice(placeholderStart);
+  const hasCompletePlaceholder = afterStart.includes(PLACEHOLDER_DELIMITERS.end);
+
+  if (hasCompletePlaceholder) {
+    return -1; // Placeholder is complete, entire string is safe
+  }
+
+  return placeholderStart; // Return position where partial placeholder starts
+}

--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { proxy } from "hono/proxy";
 import { z } from "zod";
-import { getConfig, type MaskingConfig, type SecretsDetectionConfig } from "../config";
+import { getConfig, type MaskingConfig } from "../config";
 import {
   detectSecrets,
   extractTextFromRequest,
@@ -138,11 +138,7 @@ proxyRoutes.post(
 
         // Redact action - replace secrets with placeholders and continue
         if (config.secrets_detection.action === "redact") {
-          const redactedMessages = redactMessagesWithSecrets(
-            body.messages,
-            secretsResult,
-            config.secrets_detection,
-          );
+          const redactedMessages = redactMessagesWithSecrets(body.messages, secretsResult);
           body = { ...body, messages: redactedMessages.messages };
           redactionContext = redactedMessages.context;
           secretsRedacted = true;
@@ -180,7 +176,6 @@ proxyRoutes.post(
 function redactMessagesWithSecrets(
   messages: ChatMessage[],
   secretsResult: SecretsDetectionResult,
-  config: SecretsDetectionConfig,
 ): { messages: ChatMessage[]; context: RedactionContext } {
   // Build a map of message content to redactions
   // Since we concatenated all messages with \n, we need to track positions per message
@@ -247,7 +242,6 @@ function redactMessagesWithSecrets(
             const { redacted, context: updatedContext } = redactSecrets(
               part.text,
               partRedactions,
-              config,
               context,
             );
             context = updatedContext;
@@ -287,7 +281,6 @@ function redactMessagesWithSecrets(
     const { redacted, context: updatedContext } = redactSecrets(
       msg.content,
       messageRedactions,
-      config,
       context,
     );
     context = updatedContext;

--- a/src/secrets/detect.test.ts
+++ b/src/secrets/detect.test.ts
@@ -8,7 +8,6 @@ const defaultConfig: SecretsDetectionConfig = {
   action: "block",
   entities: ["OPENSSH_PRIVATE_KEY", "PEM_PRIVATE_KEY"],
   max_scan_chars: 200000,
-  redact_placeholder: "<SECRET_REDACTED_{N}>",
   log_detected_types: true,
 };
 

--- a/src/services/stream-transformer.test.ts
+++ b/src/services/stream-transformer.test.ts
@@ -47,9 +47,9 @@ async function consumeStream(stream: ReadableStream<Uint8Array>): Promise<string
 describe("createUnmaskingStream", () => {
   test("unmasks complete placeholder in single chunk", async () => {
     const context = createMaskingContext();
-    context.mapping["<EMAIL_ADDRESS_1>"] = "test@test.com";
+    context.mapping["[[EMAIL_ADDRESS_1]]"] = "test@test.com";
 
-    const sseData = `data: {"choices":[{"delta":{"content":"Hello <EMAIL_ADDRESS_1>!"}}]}\n\n`;
+    const sseData = `data: {"choices":[{"delta":{"content":"Hello [[EMAIL_ADDRESS_1]]!"}}]}\n\n`;
     const source = createSSEStream([sseData]);
 
     const unmaskedStream = createUnmaskingStream(source, context, defaultConfig);
@@ -84,12 +84,12 @@ describe("createUnmaskingStream", () => {
 
   test("buffers partial placeholder across chunks", async () => {
     const context = createMaskingContext();
-    context.mapping["<EMAIL_ADDRESS_1>"] = "a@b.com";
+    context.mapping["[[EMAIL_ADDRESS_1]]"] = "a@b.com";
 
     // Split placeholder across chunks
     const chunks = [
-      `data: {"choices":[{"delta":{"content":"Hello <EMAIL_"}}]}\n\n`,
-      `data: {"choices":[{"delta":{"content":"ADDRESS_1> world"}}]}\n\n`,
+      `data: {"choices":[{"delta":{"content":"Hello [[EMAIL_"}}]}\n\n`,
+      `data: {"choices":[{"delta":{"content":"ADDRESS_1]] world"}}]}\n\n`,
     ];
     const source = createSSEStream(chunks);
 
@@ -102,10 +102,10 @@ describe("createUnmaskingStream", () => {
 
   test("flushes remaining buffer on stream end", async () => {
     const context = createMaskingContext();
-    context.mapping["<EMAIL_ADDRESS_1>"] = "test@test.com";
+    context.mapping["[[EMAIL_ADDRESS_1]]"] = "test@test.com";
 
     // Partial placeholder that completes only on flush
-    const chunks = [`data: {"choices":[{"delta":{"content":"Contact <EMAIL_ADDRESS_1>"}}]}\n\n`];
+    const chunks = [`data: {"choices":[{"delta":{"content":"Contact [[EMAIL_ADDRESS_1]]"}}]}\n\n`];
     const source = createSSEStream(chunks);
 
     const unmaskedStream = createUnmaskingStream(source, context, defaultConfig);
@@ -116,10 +116,10 @@ describe("createUnmaskingStream", () => {
 
   test("handles multiple placeholders in stream", async () => {
     const context = createMaskingContext();
-    context.mapping["<PERSON_1>"] = "John";
-    context.mapping["<EMAIL_ADDRESS_1>"] = "john@test.com";
+    context.mapping["[[PERSON_1]]"] = "John";
+    context.mapping["[[EMAIL_ADDRESS_1]]"] = "john@test.com";
 
-    const sseData = `data: {"choices":[{"delta":{"content":"<PERSON_1>: <EMAIL_ADDRESS_1>"}}]}\n\n`;
+    const sseData = `data: {"choices":[{"delta":{"content":"[[PERSON_1]]: [[EMAIL_ADDRESS_1]]"}}]}\n\n`;
     const source = createSSEStream([sseData]);
 
     const unmaskedStream = createUnmaskingStream(source, context, defaultConfig);

--- a/src/views/dashboard/page.tsx
+++ b/src/views/dashboard/page.tsx
@@ -525,7 +525,7 @@ function formatMaskedPreview(maskedContent, entities) {
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
-      .replace(/&lt;([A-Z_]+_\\d+)&gt;/g, '<span class="bg-accent-bg text-accent px-1 py-0.5 rounded-sm font-medium">&lt;$1&gt;</span>');
+      .replace(/\\[\\[([A-Z_]+_\\d+)\\]\\]/g, '<span class="bg-accent-bg text-accent px-1 py-0.5 rounded-sm font-medium">[[$1]]</span>');
   }
   if (!entities || entities.length === 0) {
     return '<span class="text-text-muted">No PII detected in this request</span>';


### PR DESCRIPTION
## Summary
- Changed placeholder format from `<TYPE_N>` to `[[TYPE_N]]` to fix HTML encoding issues
- Created `src/constants/placeholders.ts` as single source of truth for all placeholder logic
- Removed configurable `redact_placeholder` option (was a bug - streaming logic hardcoded `[[` detection)
- Updated dashboard regex for yellow highlighting
- Added tests for HTML/JSON/URL contexts

Fixes #36

## Breaking Changes

This PR changes the placeholder format from `<PERSON_1>` to `[[PERSON_1]]`.

**Affected:**
- Existing logs in dashboard will show old `<TYPE_N>` format (historical data)
- Any downstream tooling parsing placeholder format
- The `redact_placeholder` config option has been removed (it was broken anyway - streaming logic was hardcoded)

**Migration:** No action required. New requests will use the new format automatically.

Sorry for the breaking change, but this was necessary to fix the core issue where HTML-encoded placeholders (`&lt;PERSON_1&gt;`) couldn't be unmasked.

## Test plan
- [x] All 212 tests pass
- [x] Tested with OpenAI API calls containing PII
- [x] Verified HTML response unmasking works (the original issue)
- [x] Verified dashboard shows `[[PERSON_1]]` with yellow highlighting
- [x] Lint and typecheck pass