### PR TITLE
fix: log and display API errors in dashboard

### DIFF
--- a/src/services/llm-client.ts
+++ b/src/services/llm-client.ts
@@ -59,6 +59,20 @@ export type LLMResult =
     };
 
 /**
+ * Error from upstream LLM provider with original status code and response
+ */
+export class LLMError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: string,
+  ) {
+    super(`API error: ${status} ${statusText}`);
+    this.name = "LLMError";
+  }
+}
+
+/**
  * LLM Client for OpenAI-compatible APIs (OpenAI, Ollama, etc.)
  */
 export class LLMClient {
@@ -134,7 +148,7 @@ export class LLMClient {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`LLM API error: ${response.status} ${response.statusText} - ${errorText}`);
+      throw new LLMError(response.status, response.statusText, errorText);
     }
 
     if (isStreaming) {


### PR DESCRIPTION
## Summary

Fixes #35

- API errors (429, 401, etc.) are now logged and displayed in the dashboard
- Upstream errors pass through with original status code (was incorrectly wrapped in 502)
- Added Status column showing OK/error badges with expandable error details
- All error responses return OpenAI-compatible JSON format
- X-PasteGuard headers included in all responses (success and error)

## Changes

- `src/services/llm-client.ts`: Added `LLMError` class to preserve upstream status/body
- `src/services/logger.ts`: Added `status_code` and `error_message` columns
- `src/views/dashboard/page.tsx`: Added Status column with OK/error badges
- `src/routes/proxy.ts`: Error handling with logging and pass-through

## Test plan

- [x] 241 automated tests pass
- [x] Manual test: 401 error with invalid API key appears in dashboard
- [x] Manual test: 429 error passes through with original status
- [x] Manual test: X-PasteGuard headers present on error responses
- [x] Manual test: Successful PII request shows OK status