### PR TITLE
docs: add browser extension beta section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ PasteGuard is an OpenAI-compatible proxy that sits between your app and the LLM 
 
 Works with OpenAI, Azure, and any OpenAI-compatible API. Just change one URL.
 
+## Browser Extension (Beta)
+
+An open source browser extension that brings PasteGuard protection to ChatGPT, Claude, Gemini, Copilot, and Perplexity.
+
+- Paste customer data → PII is masked before it reaches the AI
+- You see the original, AI sees `[[PERSON_1]]`, `[[EMAIL_1]]`
+
+Open source (Apache 2.0). Built in public — early feedback shapes the product.
+
+**[Join the Beta →](https://tally.so/r/J9pNLr)**
+
 ## Features
 
 - **PII Detection** — Names, emails, phone numbers, credit cards, IBANs, and more

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -26,6 +26,19 @@ Two privacy modes:
 | **Mask** | Replace PII with placeholders, send to provider, restore in response |
 | **Route** | PII requests stay on your local LLM (Ollama, vLLM, llama.cpp), others go to your configured provider |
 
+## Browser Extension (Beta)
+
+An open source browser extension that brings PasteGuard protection to ChatGPT, Claude, Gemini, Copilot, and Perplexity.
+
+- Paste customer data → PII is masked before it reaches the AI
+- You see the original, AI sees `[[PERSON_1]]`, `[[EMAIL_1]]`
+
+Open source (Apache 2.0). Built in public — early feedback shapes the product.
+
+<Card title="Join the Beta" icon="flask" href="https://tally.so/r/J9pNLr">
+  Get early access to the browser extension
+</Card>
+
 ## Quick Example
 
 <Steps>


### PR DESCRIPTION
## Summary
- Add "Browser Extension (Beta)" section to README after Quick Start
- Add same section to docs/introduction.mdx with Card CTA
- Links to Tally form for early access signup