### PR TITLE
Simplify Quick Start docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ PasteGuard sits between your app and your provider. It's OpenAI-compatible — j
 ## Quick Start
 
 ```bash
-docker run -d --name pasteguard -p 3000:3000 ghcr.io/sgasser/pasteguard:en
+docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:en
 ```
 
 Point your app to `http://localhost:3000/openai/v1` instead of `https://api.openai.com/v1`.
 
 Dashboard: [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
 
-### Multiple Languages
+### European Languages
 
-For European languages (German, Spanish, French, Italian, Dutch, Polish, Portuguese, Romanian):
+For German, Spanish, French, Italian, Dutch, Polish, Portuguese, and Romanian:
 
 ```bash
-docker run -d --name pasteguard -p 3000:3000 ghcr.io/sgasser/pasteguard:eu
+docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:eu
 ```
 
 For custom config, persistent logs, or other languages: **[Read the docs →](https://pasteguard.com/docs/installation)**

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -22,28 +22,8 @@ ghcr.io/sgasser/pasteguard
 
 ## Quick Start
 
-**Zero-config (works out of the box):**
-
 ```bash
-docker run -d --name pasteguard -p 3000:3000 ghcr.io/sgasser/pasteguard:en
-```
-
-**With custom config and persistent logs:**
-
-```bash
-curl -O https://raw.githubusercontent.com/sgasser/pasteguard/main/config.example.yaml
-mv config.example.yaml config.yaml
-mkdir -p data
-docker run -d --name pasteguard -p 3000:3000 \
-  -v ./config.yaml:/app/config.yaml:ro \
-  -v ./data:/app/data \
-  ghcr.io/sgasser/pasteguard:en
-```
-
-**Verify:**
-
-```bash
-curl http://localhost:3000/health
+docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:en
 ```
 
 Dashboard: [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
@@ -53,7 +33,7 @@ Dashboard: [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
 For German, Spanish, French, Italian, Dutch, Polish, Portuguese, and Romanian:
 
 ```bash
-docker run -d --name pasteguard -p 3000:3000 ghcr.io/sgasser/pasteguard:eu
+docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:eu
 ```
 
 Languages are auto-configured per image — no config changes needed. The EU image automatically enables all 9 European languages.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -8,12 +8,10 @@ description: Get PasteGuard running in 2 minutes
 ## 1. Start PasteGuard
 
 ```bash
-docker run -d --name pasteguard -p 3000:3000 ghcr.io/sgasser/pasteguard:en
+docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:en
 ```
 
-That's it! PasteGuard runs on `http://localhost:3000` with sensible defaults.
-
-Dashboard: [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
+PasteGuard runs on `http://localhost:3000`. Open `http://localhost:3000/dashboard` to see the dashboard.
 
 <Note>
 For custom configuration, European languages, or persistent logs, see [Installation](/installation).


### PR DESCRIPTION
## Summary
- Remove `-d --name` flags for simpler Quick Start experience
- Use `--rm` for automatic cleanup
- Users see startup logs and immediate feedback

Before: `docker run -d --name pasteguard -p 3000:3000 ghcr.io/sgasser/pasteguard:en`
After: `docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:en`

Follows the pattern used by n8n for quick try-out commands.