### PR TITLE
Add whitelist config for masking exclusions

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -42,6 +42,10 @@ masking:
   show_markers: false
   marker_text: "[protected]"
 
+  # Text patterns that are never masked (protects against false positives)
+  # whitelist:
+  #   - "Company Name Inc."
+
 # PII Detection settings (Microsoft Presidio)
 pii_detection:
   presidio_url: ${PRESIDIO_URL:-http://localhost:5002}

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ const OpenAIProviderSchema = z.object({
 const MaskingSchema = z.object({
   show_markers: z.boolean().default(false),
   marker_text: z.string().default("[protected]"),
+  whitelist: z.array(z.string()).default([]),
 });
 
 const LanguageEnum = z.enum(SUPPORTED_LANGUAGES);

--- a/src/pii/mask.test.ts
+++ b/src/pii/mask.test.ts
@@ -17,11 +17,13 @@ import {
 const defaultConfig: MaskingConfig = {
   show_markers: false,
   marker_text: "[protected]",
+  whitelist: [],
 };
 
 const configWithMarkers: MaskingConfig = {
   show_markers: true,
   marker_text: "[protected]",
+  whitelist: [],
 };
 
 /** Helper to create a minimal request from messages */

--- a/src/providers/openai/stream-transformer.test.ts
+++ b/src/providers/openai/stream-transformer.test.ts
@@ -6,6 +6,7 @@ import { createUnmaskingStream } from "./stream-transformer";
 const defaultConfig: MaskingConfig = {
   show_markers: false,
   marker_text: "[protected]",
+  whitelist: [],
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add `masking.whitelist` config option to exclude specific text patterns from PII masking
- Useful for preventing false positives on known text like company names or product identifiers
- Patterns match bidirectionally (detected text in whitelist OR whitelist in detected text)

## Changes
- `src/config.ts`: Add whitelist property to MaskingSchema (default: empty array)
- `src/pii/detect.ts`: Add `filterWhitelistedEntities()` function
- `config.example.yaml`: Document whitelist option
- Tests updated with whitelist property