### PR TITLE
Fix OpenAI wildcard proxy host header and query string forwarding

### DIFF
--- a/src/routes/openai.ts
+++ b/src/routes/openai.ts
@@ -147,12 +147,14 @@ openaiRoutes.all("/*", (c) => {
   const config = getConfig();
   const { baseUrl } = getOpenAIInfo(config.providers.openai);
   const path = c.req.path.replace(/^\/openai\/v1/, "");
+  const query = c.req.url.includes("?") ? c.req.url.slice(c.req.url.indexOf("?")) : "";
 
-  return proxy(`${baseUrl}${path}`, {
+  return proxy(`${baseUrl}${path}${query}`, {
     ...c.req,
     headers: {
-      "Content-Type": c.req.header("Content-Type"),
-      Authorization: c.req.header("Authorization"),
+      ...c.req.header(),
+      "X-Forwarded-Host": c.req.header("host"),
+      host: undefined,
     },
   });
 });


### PR DESCRIPTION
## Summary
- Forward all headers transparently using `...c.req.header()`
- Remove `host` header to prevent localhost being forwarded to upstream
- Add `X-Forwarded-Host` with original host per Hono best practices
- Forward query string parameters

This follows Hono proxy best practices from https://hono.dev/docs/helpers/proxy