### PR TITLE
Remove SECRET_MASKED_ prefix from secrets placeholders

### DIFF
--- a/src/masking/placeholders.test.ts
+++ b/src/masking/placeholders.test.ts
@@ -23,7 +23,7 @@ describe("placeholder constants", () => {
   test("secret format uses correct delimiters", () => {
     expect(SECRET_PLACEHOLDER_FORMAT).toContain(PLACEHOLDER_DELIMITERS.start);
     expect(SECRET_PLACEHOLDER_FORMAT).toContain(PLACEHOLDER_DELIMITERS.end);
-    expect(SECRET_PLACEHOLDER_FORMAT).toBe("[[SECRET_MASKED_{N}]]");
+    expect(SECRET_PLACEHOLDER_FORMAT).toBe("[[{N}]]");
   });
 });
 
@@ -42,12 +42,12 @@ describe("generatePlaceholder", () => {
 describe("generateSecretPlaceholder", () => {
   test("generates secret placeholder", () => {
     const result = generateSecretPlaceholder("API_KEY_OPENAI", 1);
-    expect(result).toBe("[[SECRET_MASKED_API_KEY_OPENAI_1]]");
+    expect(result).toBe("[[API_KEY_OPENAI_1]]");
   });
 
   test("generates secret placeholder with different type and count", () => {
     const result = generateSecretPlaceholder("PEM_PRIVATE_KEY", 2);
-    expect(result).toBe("[[SECRET_MASKED_PEM_PRIVATE_KEY_2]]");
+    expect(result).toBe("[[PEM_PRIVATE_KEY_2]]");
   });
 });
 

--- a/src/masking/placeholders.ts
+++ b/src/masking/placeholders.ts
@@ -10,8 +10,8 @@ export const PLACEHOLDER_DELIMITERS = {
 /** PII placeholder format: [[TYPE_N]] e.g. [[PERSON_1]], [[EMAIL_ADDRESS_2]] */
 export const PII_PLACEHOLDER_FORMAT = "[[{TYPE}_{N}]]";
 
-/** Secrets placeholder format: [[SECRET_MASKED_TYPE_N]] e.g. [[SECRET_MASKED_API_KEY_OPENAI_1]] */
-export const SECRET_PLACEHOLDER_FORMAT = "[[SECRET_MASKED_{N}]]";
+/** Secrets placeholder format: [[TYPE_N]] e.g. [[API_KEY_OPENAI_1]] */
+export const SECRET_PLACEHOLDER_FORMAT = "[[{N}]]";
 
 /**
  * Generates a placeholder string from the format

--- a/src/routes/api.test.ts
+++ b/src/routes/api.test.ts
@@ -163,7 +163,7 @@ describe("POST /api/mask", () => {
       masked: string;
       entities: { type: string }[];
     };
-    expect(body.masked).toContain("[[SECRET_MASKED_PEM_PRIVATE_KEY_1]]");
+    expect(body.masked).toContain("[[PEM_PRIVATE_KEY_1]]");
     expect(body.entities.some((e) => e.type === "PEM_PRIVATE_KEY")).toBe(true);
   });
 
@@ -209,11 +209,11 @@ describe("POST /api/mask", () => {
 
     // Both PII and secrets should be masked
     expect(body.masked).toContain("[[EMAIL_ADDRESS_1]]");
-    expect(body.masked).toContain("[[SECRET_MASKED_PEM_PRIVATE_KEY_1]]");
+    expect(body.masked).toContain("[[PEM_PRIVATE_KEY_1]]");
 
     // Context should contain mappings for both
     expect(body.context["[[EMAIL_ADDRESS_1]]"]).toBe("john@example.com");
-    expect(body.context["[[SECRET_MASKED_PEM_PRIVATE_KEY_1]]"]).toBeDefined();
+    expect(body.context["[[PEM_PRIVATE_KEY_1]]"]).toBeDefined();
 
     // Entities should include both types
     expect(body.entities.some((e) => e.type === "EMAIL_ADDRESS")).toBe(true);


### PR DESCRIPTION
## Summary
- Simplify placeholder format by using `[[TYPE_N]]` for both PII and secrets
- Makes the format consistent and shorter

**Before:** `[[SECRET_MASKED_API_KEY_OPENAI_1]]`
**After:** `[[API_KEY_OPENAI_1]]`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] Related tests pass (209 tests)