### PR TITLE
Increase Presidio startup timeout for multi-language images

### DIFF
--- a/docs/configuration/pii-detection.mdx
+++ b/docs/configuration/pii-detection.mdx
@@ -38,6 +38,8 @@ Languages are auto-configured per Docker image:
 - **`:en` image** → English only
 - **`:eu` image** → English, German, Spanish, French, Italian, Dutch, Polish, Portuguese, Romanian
 
+Each language adds ~10s to startup time as spaCy models are loaded.
+
 For custom language builds:
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,9 +117,10 @@ async function validateStartup() {
 
   const detector = getPIIDetector();
 
-  // Wait for Presidio to be ready
+  // Wait for Presidio to be ready (multi-language setups need longer to load spaCy models)
+  const startupTimeout = Number(process.env.PASTEGUARD_STARTUP_TIMEOUT) || 180;
   console.log("[STARTUP] Connecting to Presidio...");
-  const ready = await detector.waitForReady(30, 1000);
+  const ready = await detector.waitForReady(startupTimeout, 1000);
 
   if (!ready) {
     console.error(


### PR DESCRIPTION
## Summary
- Increase default Presidio startup timeout from 30s to 180s
- Add `PRESIDIO_STARTUP_TIMEOUT` env var for customization
- Document startup time in config and docs

The EU image loads 9 spaCy language models which takes ~2 minutes. The previous 30-second timeout caused PasteGuard to restart multiple times before Presidio was ready.

Fixes #58