### PR TITLE
Release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Release v0.3.0

Version bump for the v0.3.0 release.

### Changes in this release:

- Generic Mask API (`/api/mask` endpoint)
- Dashboard source tracking
- Cleaner placeholder format for secrets
- Renamed `API_KEY_OPENAI` to `API_KEY_SK`
- Increased Presidio startup timeout
- Fixed entity extraction

See the GitHub release notes for full details.