### PR TITLE
Fix SIGILL crash on CPUs without AVX2 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
       - path: .env
         required: false
     volumes:
-      - ./config.yaml:/app/config.yaml:ro
-      - ./data:/app/data
+      - ./config.yaml:/pasteguard/config.yaml:ro
+      - ./data:/pasteguard/data
     restart: unless-stopped
 
   # Development: Only Presidio (for local Bun with hot-reload)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # Single container with Proxy + PII Detection
 #
 # Build: docker build -f docker/Dockerfile --build-arg LANGUAGES=en -t pasteguard:en .
-# Run:   docker run -p 3000:3000 -v ./config.yaml:/app/config.yaml -v ./data:/app/data pasteguard:en
+# Run:   docker run -p 3000:3000 -v ./config.yaml:/pasteguard/config.yaml -v ./data:/pasteguard/data pasteguard:en
 
 ARG LANGUAGES="en"
 
@@ -42,13 +42,14 @@ COPY tsconfig.json ./
 # =============================================================================
 FROM mcr.microsoft.com/presidio-analyzer:latest
 
+USER root
+
 ARG LANGUAGES
 
 # Install supervisor for process management
 RUN apt-get update && apt-get install -y --no-install-recommends \
     supervisor \
     curl \
-    unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -61,32 +62,38 @@ RUN if echo "${LANGUAGES}" | grep -q "ja"; then \
     fi
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install Bun
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+# Copy Bun binary from official image (uses baseline build for x64 compatibility)
+# The official oven/bun images use baseline builds which only require SSE4.2,
+# supporting older/low-power x86_64 CPUs (e.g., Intel Atom C3558R) that lack AVX2.
+# See: https://github.com/sgasser/pasteguard/issues/70
+COPY --from=bun-builder /usr/local/bin/bun /usr/local/bin/bun
+ENV PATH="/usr/local/bin:${PATH}"
 
 # Copy Presidio configuration
-COPY --from=generator /output/nlp-config.yaml /usr/bin/presidio_analyzer/conf/default.yaml
-COPY --from=generator /output/recognizers-config.yaml /usr/bin/presidio_analyzer/conf/default_recognizers.yaml
-COPY --from=generator /output/analyzer-config.yaml /usr/bin/presidio_analyzer/conf/default_analyzer.yaml
+COPY --from=generator /output/nlp-config.yaml /app/presidio_analyzer/conf/default.yaml
+COPY --from=generator /output/recognizers-config.yaml /app/presidio_analyzer/conf/default_recognizers.yaml
+COPY --from=generator /output/analyzer-config.yaml /app/presidio_analyzer/conf/default_analyzer.yaml
 
 # Install spaCy models
 COPY --from=generator /output/install-models.sh /tmp/
 RUN chmod +x /tmp/install-models.sh && /tmp/install-models.sh && rm /tmp/install-models.sh
 
-# Copy Bun application
-WORKDIR /app
+# Copy Bun application to /pasteguard (separate from Presidio's /app)
+WORKDIR /pasteguard
 COPY --from=bun-builder /app/node_modules ./node_modules
 COPY --from=bun-builder /app/src ./src
 COPY --from=bun-builder /app/package.json ./
 COPY --from=bun-builder /app/tsconfig.json ./
 COPY config.example.yaml ./
 
-# Create data directory
-RUN mkdir -p /app/data
+# Create data directory and set permissions for non-root user
+RUN mkdir -p /pasteguard/data && chown -R 1001:1001 /pasteguard
 
 # Copy supervisor configuration
 COPY docker/supervisord.conf /etc/supervisor/conf.d/pasteguard.conf
+
+# Switch back to non-root user for runtime
+USER 1001
 
 # Environment defaults
 ENV PRESIDIO_URL=http://localhost:5002

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,13 +1,13 @@
 [supervisord]
 nodaemon=true
-user=root
-logfile=/var/log/supervisor/supervisord.log
-pidfile=/var/run/supervisord.pid
+logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
 loglevel=info
 
 [program:presidio]
 command=poetry run gunicorn -w %(ENV_WORKERS)s -b 0.0.0.0:%(ENV_PORT)s --timeout 300 --preload "app:create_app()"
-directory=/usr/bin
+directory=/app
 autostart=true
 autorestart=true
 startsecs=10
@@ -19,8 +19,8 @@ stderr_logfile_maxbytes=0
 priority=10
 
 [program:pasteguard]
-command=/root/.bun/bin/bun run src/index.ts
-directory=/app
+command=/usr/local/bin/bun run src/index.ts
+directory=/pasteguard
 autostart=%(ENV_START_APP)s
 autorestart=true
 startsecs=5

--- a/docs/configuration/logging.mdx
+++ b/docs/configuration/logging.mdx
@@ -33,7 +33,7 @@ In Docker, this is persisted via volume:
 
 ```yaml
 volumes:
-  - ./data:/app/data
+  - ./data:/pasteguard/data
 ```
 
 ## Retention

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -50,8 +50,8 @@ mkdir -p data
 
 # Run with persistence
 docker run -d --name pasteguard --restart unless-stopped -p 3000:3000 \
-  -v ./config.yaml:/app/config.yaml:ro \
-  -v ./data:/app/data \
+  -v ./config.yaml:/pasteguard/config.yaml:ro \
+  -v ./data:/pasteguard/data \
   ghcr.io/sgasser/pasteguard:en
 ```
 


### PR DESCRIPTION
## Summary

Fixes #70 - PasteGuard crashes with `SIGILL` on x86_64 CPUs without AVX2 support (e.g., Intel Atom C3558R).

**Root cause:** The Bun install script detected AVX2 on the GitHub Actions build host and installed the optimized binary. When run on CPUs without AVX2, it crashed immediately.

**Fix:** Copy the Bun binary directly from the official `oven/bun:1-slim` builder stage. The official images use baseline builds for x64, which only require SSE4.2.

Also fixes compatibility with the updated `presidio-analyzer` base image which now runs as non-root user.

## Changes

- `docker/Dockerfile`:
  - Copy Bun from builder stage instead of using install script
  - Add `USER root` for apt-get commands
  - Fix Presidio config paths (`/app/presidio_analyzer/conf/`)
  - Move PasteGuard to `/pasteguard` to avoid directory conflict with Presidio

- `docker/supervisord.conf`:
  - Update Presidio directory to `/app`
  - Update PasteGuard directory to `/pasteguard`
  - Update Bun path to `/usr/local/bin/bun`

## Tested

- [x] Docker image builds successfully
- [x] Both Presidio and PasteGuard services start correctly
- [x] Health endpoint returns 200