### PR TITLE
fix: use UID 1000 for container user to match typical Linux host users

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,14 +86,14 @@ COPY --from=bun-builder /app/package.json ./
 COPY --from=bun-builder /app/tsconfig.json ./
 COPY config.example.yaml ./
 
-# Create data directory and set permissions for non-root user
-RUN mkdir -p /pasteguard/data && chown -R 1001:1001 /pasteguard
+# Create data directory and set permissions for UID 1000 (matches most Linux users)
+RUN mkdir -p /pasteguard/data && chown -R 1000:1000 /pasteguard
 
 # Copy supervisor configuration
 COPY docker/supervisord.conf /etc/supervisor/conf.d/pasteguard.conf
 
-# Switch back to non-root user for runtime
-USER 1001
+# Switch to non-root user for runtime
+USER 1000
 
 # Environment defaults
 ENV PRESIDIO_URL=http://localhost:5002


### PR DESCRIPTION
## Summary
- Changes container UID from 1001 to 1000
- Fixes permission denied errors when mounting volumes

## Root cause
The Presidio base image uses UID 1001, but most Linux desktop users have UID 1000. When bind-mounting `./data`, the host directory is owned by UID 1000, so the container process (UID 1001) couldn't write to it.

## Test plan
- [ ] Build image locally: `docker compose build`
- [ ] Run with volume mount: `docker compose up -d`
- [ ] Verify no permission errors in logs: `docker compose logs pasteguard`

Fixes #76