### PR TITLE
Fix route test PII detector mock isolation

### DIFF
--- a/src/routes/api.test.ts
+++ b/src/routes/api.test.ts
@@ -9,6 +9,8 @@ const mockDetectPII = mock<(text: string, language: string) => Promise<PIIEntity
 mock.module("../pii/detect", () => ({
   getPIIDetector: () => ({
     detectPII: mockDetectPII,
+    healthCheck: mock(() => Promise.resolve(true)),
+    getLanguageValidation: mock(() => undefined),
   }),
   filterWhitelistedEntities,
 }));


### PR DESCRIPTION
## Summary

Fixes route test order sensitivity by making the `../pii/detect` mock in `src/routes/api.test.ts` include the detector methods used by other route tests.

## Why

CI for PR #84 exposed that `api.test.ts` can run before `info.test.ts` or `health.test.ts` on newer Bun versions. Because `mock.module("../pii/detect")` is process-global for the test run, later route tests can see the API test's mocked detector. The previous mock only implemented `detectPII`, so `/info` failed on `getLanguageValidation()` and `/health` could fail on `healthCheck()` depending on test order.

## Verification

- `bun test src/routes/api.test.ts src/routes/info.test.ts src/routes/health.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun test`
- Simulated this fix together with PR #84 and reran typecheck, Biome, targeted route/OpenAI tests, and the full test suite.
