### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- bump PasteGuard package version to 0.4.1 for the security dependency release

## Validation
- bun audit --json
- bun run typecheck
- bun run check
- bun test