### PR TITLE
Fix masked content not logged when secrets are detected

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -156,8 +156,7 @@ secrets_detection:
   # The 200KB default covers typical use cases
   max_scan_chars: 200000
 
-  # Log detected secret types (never logs secret content)
-  # Even if logging.log_content is true, secret content is never logged
+  # Log detected secret types (never logs raw secret content)
   log_detected_types: true
 
   # Which message roles to scan for secrets (optional)
@@ -178,11 +177,8 @@ logging:
   # Log retention in days (0 = keep forever)
   retention_days: 30
 
-  # Log request/response content (may contain sensitive data!)
-  log_content: false
-
   # Log masked content for dashboard preview (default: true)
-  # Shows what was actually sent to provider with PII replaced by placeholders
+  # Shows what was actually sent to provider with PII and secrets replaced by placeholders
   # Disable if you don't want any content stored, even masked
   log_masked_content: true
 

--- a/docs/api-reference/status.mdx
+++ b/docs/api-reference/status.mdx
@@ -86,6 +86,17 @@ curl http://localhost:3000/info
     "score_threshold": 0.7,
     "entities": ["PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER"]
   },
+  "secrets_detection": {
+    "enabled": true,
+    "action": "mask",
+    "entities": ["OPENSSH_PRIVATE_KEY", "PEM_PRIVATE_KEY"],
+    "max_scan_chars": 200000,
+    "log_detected_types": true
+  },
+  "logging": {
+    "retention_days": 30,
+    "log_masked_content": true
+  },
   "masking": {
     "show_markers": false
   }

--- a/docs/configuration/logging.mdx
+++ b/docs/configuration/logging.mdx
@@ -74,4 +74,4 @@ Only metadata (timestamps, models, PII detected) is logged.
 - Raw request/response content is **never** logged — only the masked version, and only when `log_masked_content` is enabled
 - With `secrets_detection.action: route_local`, content is not logged at all when secrets are detected, since secrets stay unmasked for the local provider
 - Only secret types are logged if `log_detected_types: true`
-- Masked content shows placeholders like `[[EMAIL_ADDRESS_1]]` and `[API_KEY_SK_1]`, not real values
+- Masked content shows placeholders like `[[EMAIL_ADDRESS_1]]` and `[[API_KEY_SK_1]]`, not real values

--- a/docs/configuration/logging.mdx
+++ b/docs/configuration/logging.mdx
@@ -7,7 +7,6 @@ description: Configure request logging
 logging:
   database: ./data/pasteguard.db
   retention_days: 30
-  log_content: false
   log_masked_content: true
 ```
 
@@ -17,7 +16,6 @@ logging:
 |--------|---------|-------------|
 | `database` | `./data/pasteguard.db` | SQLite database path |
 | `retention_days` | `30` | Days to keep logs. `0` = forever |
-| `log_content` | `false` | Log raw request/response (contains PII!) |
 | `log_masked_content` | `true` | Log masked version for dashboard |
 
 ## Database
@@ -49,33 +47,23 @@ logging:
 
 ## Content Logging
 
-### Raw Content (not recommended)
-
-Logs original request/response including PII:
-
-```yaml
-logging:
-  log_content: true  # Contains sensitive data!
-```
-
 ### Masked Content (default)
 
-Logs masked version for dashboard preview:
+Logs the masked version for dashboard preview:
 
 ```yaml
 logging:
   log_masked_content: true
 ```
 
-Shows what was actually sent upstream with PII replaced by placeholders.
+Shows what was actually sent upstream with PII and secrets replaced by placeholders.
 
 ### No Content
 
-Disable all content logging:
+Disable content logging:
 
 ```yaml
 logging:
-  log_content: false
   log_masked_content: false
 ```
 
@@ -83,6 +71,7 @@ Only metadata (timestamps, models, PII detected) is logged.
 
 ## Security
 
-- Secret content is **never** logged, even if `log_content: true`
+- Raw request/response content is **never** logged — only the masked version, and only when `log_masked_content` is enabled
+- With `secrets_detection.action: route_local`, content is not logged at all when secrets are detected, since secrets stay unmasked for the local provider
 - Only secret types are logged if `log_detected_types: true`
-- Masked content shows placeholders like `[[EMAIL_ADDRESS_1]]`, not real PII
+- Masked content shows placeholders like `[[EMAIL_ADDRESS_1]]` and `[API_KEY_SK_1]`, not real values

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,7 +83,6 @@ const ServerSchema = z.object({
 const LoggingSchema = z.object({
   database: z.string().default("./data/pasteguard.db"),
   retention_days: z.coerce.number().int().min(0).default(30),
-  log_content: z.boolean().default(false),
   log_masked_content: z.boolean().default(true),
 });
 

--- a/src/routes/info.test.ts
+++ b/src/routes/info.test.ts
@@ -23,6 +23,21 @@ describe("GET /info", () => {
     expect(body.pii_detection).toBeDefined();
   });
 
+  test("includes secrets_detection and logging sections", async () => {
+    const res = await app.request("/info");
+
+    const body = (await res.json()) as Record<string, Record<string, unknown>>;
+    expect(body.secrets_detection).toBeDefined();
+    expect(body.secrets_detection.enabled).toBeDefined();
+    expect(body.secrets_detection.action).toBeDefined();
+    expect(body.secrets_detection.entities).toBeDefined();
+    expect(body.logging).toBeDefined();
+    expect(body.logging.retention_days).toBeDefined();
+    expect(body.logging.log_masked_content).toBeDefined();
+    // Database path is intentionally not exposed
+    expect(body.logging.database).toBeUndefined();
+  });
+
   test("returns correct content-type", async () => {
     const res = await app.request("/info");
 

--- a/src/routes/info.ts
+++ b/src/routes/info.ts
@@ -43,6 +43,17 @@ infoRoutes.get("/info", (c) => {
       score_threshold: config.pii_detection.score_threshold,
       entities: config.pii_detection.entities,
     },
+    secrets_detection: {
+      enabled: config.secrets_detection.enabled,
+      action: config.secrets_detection.action,
+      entities: config.secrets_detection.entities,
+      max_scan_chars: config.secrets_detection.max_scan_chars,
+      log_detected_types: config.secrets_detection.log_detected_types,
+    },
+    logging: {
+      retention_days: config.logging.retention_days,
+      log_masked_content: config.logging.log_masked_content,
+    },
   };
 
   if (config.mode === "route" && config.local) {

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -239,6 +239,7 @@ export function createLogData(options: CreateLogDataOptions): RequestLogData {
     detectedLanguage: pii?.detectedLanguage,
     maskedContent,
     secretsDetected: secrets?.detected,
+    secretsMasked: secrets?.masked,
     secretsTypes: secrets?.types,
     statusCode,
     errorMessage,

--- a/src/services/log-content.test.ts
+++ b/src/services/log-content.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { shouldLogMaskedContent } from "./log-content";
+
+describe("shouldLogMaskedContent", () => {
+  // With action "mask", maskedContent has both PII and secrets replaced by
+  // placeholders, e.g. "My key is [API_KEY_SK_1] and email [[EMAIL_ADDRESS_1]]".
+  // Storing it is safe even when secrets were detected (issue #91).
+  const maskedWithSecret = "My key is [API_KEY_SK_1] and email [[EMAIL_ADDRESS_1]]";
+  const maskedPiiOnly = "Email [[EMAIL_ADDRESS_1]]";
+
+  test("logs masked content when secrets were detected and masked", () => {
+    expect(
+      shouldLogMaskedContent({
+        maskedContent: maskedWithSecret,
+        logMaskedContent: true,
+        secretsDetected: true,
+        secretsMasked: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("logs masked content when only PII was detected", () => {
+    expect(
+      shouldLogMaskedContent({
+        maskedContent: maskedPiiOnly,
+        logMaskedContent: true,
+        secretsDetected: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not log when log_masked_content is false", () => {
+    expect(
+      shouldLogMaskedContent({
+        maskedContent: maskedWithSecret,
+        logMaskedContent: false,
+        secretsDetected: true,
+        secretsMasked: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldLogMaskedContent({
+        maskedContent: maskedPiiOnly,
+        logMaskedContent: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not log when secrets were detected but not masked (route_local)", () => {
+    // Route mode with action "route_local" leaves secrets raw for the trusted
+    // local provider, so the content may contain actual secret material.
+    expect(
+      shouldLogMaskedContent({
+        maskedContent: "My key is sk-live-actual-secret and email [[EMAIL_ADDRESS_1]]",
+        logMaskedContent: true,
+        secretsDetected: true,
+        secretsMasked: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not log when there is no masked content", () => {
+    expect(
+      shouldLogMaskedContent({
+        maskedContent: undefined,
+        logMaskedContent: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/services/log-content.test.ts
+++ b/src/services/log-content.test.ts
@@ -3,9 +3,9 @@ import { shouldLogMaskedContent } from "./log-content";
 
 describe("shouldLogMaskedContent", () => {
   // With action "mask", maskedContent has both PII and secrets replaced by
-  // placeholders, e.g. "My key is [API_KEY_SK_1] and email [[EMAIL_ADDRESS_1]]".
+  // placeholders, e.g. "My key is [[API_KEY_SK_1]] and email [[EMAIL_ADDRESS_1]]".
   // Storing it is safe even when secrets were detected (issue #91).
-  const maskedWithSecret = "My key is [API_KEY_SK_1] and email [[EMAIL_ADDRESS_1]]";
+  const maskedWithSecret = "My key is [[API_KEY_SK_1]] and email [[EMAIL_ADDRESS_1]]";
   const maskedPiiOnly = "Email [[EMAIL_ADDRESS_1]]";
 
   test("logs masked content when secrets were detected and masked", () => {

--- a/src/services/log-content.ts
+++ b/src/services/log-content.ts
@@ -9,7 +9,7 @@ export interface LogContentDecision {
  * Decide whether masked content should be persisted to the request log.
  *
  * When secrets_detection.action is "mask" (the default), maskedContent has both
- * PII and secrets replaced by placeholders (e.g. "[API_KEY_SK_1]",
+ * PII and secrets replaced by placeholders (e.g. "[[API_KEY_SK_1]]",
  * "[[EMAIL_ADDRESS_1]]") by the time it reaches the logger, so it is safe to
  * store even when secrets were detected — gating follows log_masked_content.
  *

--- a/src/services/log-content.ts
+++ b/src/services/log-content.ts
@@ -1,0 +1,26 @@
+export interface LogContentDecision {
+  maskedContent?: string;
+  logMaskedContent: boolean;
+  secretsDetected?: boolean;
+  secretsMasked?: boolean;
+}
+
+/**
+ * Decide whether masked content should be persisted to the request log.
+ *
+ * When secrets_detection.action is "mask" (the default), maskedContent has both
+ * PII and secrets replaced by placeholders (e.g. "[API_KEY_SK_1]",
+ * "[[EMAIL_ADDRESS_1]]") by the time it reaches the logger, so it is safe to
+ * store even when secrets were detected — gating follows log_masked_content.
+ *
+ * The exception is route mode with action "route_local": secrets are detected
+ * but intentionally left unmasked for the trusted local provider, so the
+ * content may contain raw secret material and must never be persisted.
+ */
+export function shouldLogMaskedContent(decision: LogContentDecision): boolean {
+  const { maskedContent, logMaskedContent, secretsDetected, secretsMasked } = decision;
+  if (!maskedContent || !logMaskedContent) return false;
+  // Detected but unmasked secrets (action: route_local) are still raw in the content
+  if (secretsDetected && !secretsMasked) return false;
+  return true;
+}

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { getConfig } from "../config";
+import { shouldLogMaskedContent } from "./log-content";
 
 export interface RequestLog {
   id?: number;
@@ -302,6 +303,7 @@ export interface RequestLogData {
   detectedLanguage?: string;
   maskedContent?: string;
   secretsDetected?: boolean;
+  secretsMasked?: boolean;
   secretsTypes?: string[];
   statusCode?: number;
   errorMessage?: string;
@@ -312,9 +314,12 @@ export function logRequest(data: RequestLogData, userAgent: string | null): void
     const config = getConfig();
     const logger = getLogger();
 
-    // Safety: Never log content if secrets were detected
-    // Even if log_content is true, secrets are never logged
-    const shouldLogContent = data.maskedContent && !data.secretsDetected;
+    const shouldLogContent = shouldLogMaskedContent({
+      maskedContent: data.maskedContent,
+      logMaskedContent: config.logging.log_masked_content,
+      secretsDetected: data.secretsDetected,
+      secretsMasked: data.secretsMasked,
+    });
 
     // Only log secret types if configured to do so
     const shouldLogSecretTypes =

--- a/src/views/dashboard/page.tsx
+++ b/src/views/dashboard/page.tsx
@@ -542,7 +542,7 @@ function formatMaskedPreview(maskedContent, entities) {
   if (!entities || entities.length === 0) {
     return '<span class="text-text-muted">No PII detected in this request</span>';
   }
-  return '<span class="text-text-muted">Masked content not logged (log_masked_content: false)</span>';
+  return '<span class="text-text-muted">Masked content not logged</span>';
 }
 
 function renderEntityList(entities) {


### PR DESCRIPTION
## Summary

Fixes #91. When secrets were detected, masked content was never stored — regardless of `log_masked_content: true` — and the dashboard showed a misleading *"Masked content not logged (log_masked_content: false)"* message.

The root cause (correctly diagnosed by @v1rusnl in the issue) was in `src/services/logger.ts`:

```ts
const shouldLogContent = data.maskedContent && !data.secretsDetected;
```

With `secrets_detection.action: mask` (the default), `maskedContent` already has **both** PII and secrets replaced by placeholders (e.g. `[API_KEY_SK_1]`, `[[EMAIL_ADDRESS_1]]`) by the time `logRequest` runs, so it is safe to store. The gate now allows it while still protecting the one path where content can contain raw secret material:

- **`action: mask`** (default) → secrets masked → content logged per `log_masked_content` ✅
- **`action: route_local`** (route mode) → secrets detected but intentionally left raw for the trusted local provider → content is **never** logged, same as before 🔒
- **`action: block`** → request rejected, no content logged (unchanged)

This also closes a quieter inconsistency: the `openai`/`anthropic`/`codex` routes passed `maskedContent` to the logger unconditionally, so the logger never enforced `log_masked_content` for them. Gating centrally fixes that for every route.

## Follow-ups from the issue (also in this PR)

- **`/info` now includes `secrets_detection` and `logging` sections** — the reporter pointed out he couldn't verify his logging config was loaded. (Database path intentionally not exposed.)
- **Dashboard fallback message fixed** — it no longer claims `log_masked_content: false` when content is absent for another reason.
- **Removed the unused `log_content` option** — it was defined in config and documented ("Log raw request/response"), but no code ever read it. Implementing raw-content logging would contradict the privacy guarantees, so it's removed instead. Zod strips unknown keys, so existing configs that still set `log_content` keep loading fine.

Raw secret content is still never logged — the security guarantees in `docs/configuration/logging.mdx` are unchanged (docs updated to match reality).

## Changes

- `src/services/log-content.ts` — new `shouldLogMaskedContent` helper (own module so the unit test can import it without tripping over the wholesale logger mock used by other route tests).
- `src/services/logger.ts` — gate on `log_masked_content` + secrets-actually-masked instead of bare `secretsDetected`.
- `src/routes/utils.ts` — thread `secretsMasked` into the log data.
- `src/routes/info.ts` — expose `secrets_detection` and `logging` config.
- `src/views/dashboard/page.tsx` — neutral "Masked content not logged" message.
- `src/config.ts`, `config.example.yaml`, `docs/` — remove dead `log_content` option, update logging docs and `/info` API reference.
- Tests: `src/services/log-content.test.ts` (new), `src/routes/info.test.ts` (extended).

## Verification

- `bun test` → 335 pass, 0 fail
- `bun run typecheck` → clean
- `bun run check` (Biome) → clean