### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- bump PasteGuard package version to 0.4.2 for the masked-content logging fix (#91, #92)

## Validation
- bun test
- bun run typecheck
- bun run check