### PR TITLE
Add Conductor workspace configuration

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,16 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
+
+[scripts]
+setup = """
+bun install
+if [ ! -f config.yaml ]; then
+  sed 's/port: 3000/port: ${CONDUCTOR_PORT:-3000}/' config.example.yaml > config.yaml
+fi
+mkdir -p data
+"""
+run = """
+docker compose -p pasteguard-dev --profile dev up presidio -d
+CONDUCTOR_PORT=${CONDUCTOR_PORT:-3000} bun run dev
+"""
+archive = "true"
+run_mode = "concurrent"


### PR DESCRIPTION
Adds `.conductor/settings.toml` so PasteGuard runs cleanly in parallel Conductor workspaces. The setup script installs dependencies, creates `config.yaml` from the example with the port wired to `${CONDUCTOR_PORT:-3000}` (resolved at runtime by the existing env-var interpolation), and creates the `data` directory. The run script starts a shared Presidio container via a fixed Compose project name and launches the dev server on the per-workspace port, and `run_mode = "concurrent"` is safe because HTTP ports are per-workspace while Presidio is shared.