### PR TITLE
Add configurable masking denylist and regex whitelist

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -52,7 +52,9 @@ masking:
 
   # Text patterns that are never masked (protects against false positives)
   # whitelist:
-  #   - "Company Name Inc."
+  #   - pattern: "Company Name Inc."
+  #   - pattern: 'TEST-\d+'
+  #     regex: true
 
   # Text or regex patterns that are always masked, even if the detector misses them
   # denylist:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,6 +54,14 @@ masking:
   # whitelist:
   #   - "Company Name Inc."
 
+  # Text or regex patterns that are always masked, even if the detector misses them
+  # denylist:
+  #   - pattern: "ProjectX"
+  #     type: PROJECT_NAME
+  #   - pattern: 'CUST-\d{6}'
+  #     type: CUSTOMER_ID
+  #     regex: true
+
 # PII Detection settings (detector service, /analyze contract)
 pii_detection:
   # URL of the detector service (see detector/). Defaults to localhost, which is

--- a/docs/concepts/mask-mode.mdx
+++ b/docs/concepts/mask-mode.mdx
@@ -46,6 +46,10 @@ providers:
 masking:
   show_markers: false
   marker_text: "[protected]"
+  whitelist:
+    - pattern: "Company Name Inc."
+    - pattern: 'TEST-\d+'
+      regex: true
   denylist:
     - pattern: "ProjectX"
       type: PROJECT_NAME
@@ -58,7 +62,7 @@ masking:
 |--------|---------|-------------|
 | `show_markers` | `false` | Add visual markers around unmasked values |
 | `marker_text` | `[protected]` | Marker text if enabled |
-| `whitelist` | built-in Claude Code prompt whitelist | Text patterns that are never masked |
+| `whitelist` | built-in Claude Code prompt whitelist | Text patterns that are never masked; set `regex: true` for regex patterns |
 | `denylist` | `[]` | Text patterns that are always masked with the configured `type`; set `regex: true` for regex patterns |
 
 ## Response Headers

--- a/docs/concepts/mask-mode.mdx
+++ b/docs/concepts/mask-mode.mdx
@@ -62,7 +62,7 @@ masking:
 |--------|---------|-------------|
 | `show_markers` | `false` | Add visual markers around unmasked values |
 | `marker_text` | `[protected]` | Marker text if enabled |
-| `whitelist` | built-in Claude Code prompt whitelist | Text patterns that are never masked; set `regex: true` for regex patterns |
+| `whitelist` | `[]` | Text patterns that are never masked; set `regex: true` for regex patterns |
 | `denylist` | `[]` | Text patterns that are always masked with the configured `type`; set `regex: true` for regex patterns |
 
 ## Response Headers

--- a/docs/concepts/mask-mode.mdx
+++ b/docs/concepts/mask-mode.mdx
@@ -46,12 +46,20 @@ providers:
 masking:
   show_markers: false
   marker_text: "[protected]"
+  denylist:
+    - pattern: "ProjectX"
+      type: PROJECT_NAME
+    - pattern: 'CUST-\d{6}'
+      type: CUSTOMER_ID
+      regex: true
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `show_markers` | `false` | Add visual markers around unmasked values |
 | `marker_text` | `[protected]` | Marker text if enabled |
+| `whitelist` | built-in Claude Code prompt whitelist | Text patterns that are never masked |
+| `denylist` | `[]` | Text patterns that are always masked with the configured `type`; set `regex: true` for regex patterns |
 
 ## Response Headers
 

--- a/docs/configuration/pii-detection.mdx
+++ b/docs/configuration/pii-detection.mdx
@@ -92,11 +92,13 @@ Exclude specific text patterns from PII masking. Useful for preventing false pos
 ```yaml
 masking:
   whitelist:
-    - "Acme Corp"
-    - "Product XYZ"
+    - pattern: "Acme Corp"
+    - pattern: "Product XYZ"
+    - pattern: 'TEST-\d+'
+      regex: true
 ```
 
-Patterns match bidirectionally - detected text containing a whitelist entry (or vice versa) is excluded.
+Literal patterns match bidirectionally - detected text containing a whitelist entry (or vice versa) is excluded. Set `regex: true` to match detected text with JavaScript regular expression syntax.
 
 ## Denylist
 

--- a/docs/configuration/pii-detection.mdx
+++ b/docs/configuration/pii-detection.mdx
@@ -116,8 +116,6 @@ masking:
 
 Patterns are matched literally by default. Set `regex: true` to use JavaScript regular expression syntax, and use single quotes in YAML when the pattern contains backslashes. A regex pattern must not match the empty string (e.g. use `\d+`, not `\d*`); such a pattern is rejected at startup because it would silently mask nothing. Matches that fall inside an already-masked placeholder are ignored.
 
-<Warning>Whitelist and denylist regexes run against request content on every request. PasteGuard checks that a pattern compiles but does not guard against catastrophic backtracking — use simple, non-backtracking expressions to avoid a denial-of-service from a pathological pattern.</Warning>
-
 ## Scan Roles
 
 By default, all message roles are scanned. To scan only user-controlled content:

--- a/docs/configuration/pii-detection.mdx
+++ b/docs/configuration/pii-detection.mdx
@@ -98,6 +98,22 @@ masking:
 
 Patterns match bidirectionally - detected text containing a whitelist entry (or vice versa) is excluded.
 
+## Denylist
+
+Force specific text or regex patterns to be masked, even when the detector does not report them or PII detection is disabled. Each entry needs a `type`, which is used for the placeholder name.
+
+```yaml
+masking:
+  denylist:
+    - pattern: "ProjectX"
+      type: PROJECT_NAME
+    - pattern: 'CUST-\d{6}'
+      type: CUSTOMER_ID
+      regex: true
+```
+
+Patterns are matched literally by default. Set `regex: true` to use JavaScript regular expression syntax, and use single quotes in YAML when the pattern contains backslashes.
+
 ## Scan Roles
 
 By default, all message roles are scanned. To scan only user-controlled content:

--- a/docs/configuration/pii-detection.mdx
+++ b/docs/configuration/pii-detection.mdx
@@ -98,7 +98,7 @@ masking:
       regex: true
 ```
 
-Literal patterns match bidirectionally - detected text containing a whitelist entry (or vice versa) is excluded. Set `regex: true` to match with JavaScript regular expression syntax; a regex whitelist entry must match the **entire** detected value (so `\d{4}` will not un-mask a longer number that merely contains four digits).
+A literal entry is matched as a substring: a detected value is left unmasked if it contains the entry, or the entry contains it. Set `regex: true` for JavaScript regex syntax — a regex entry must match the **entire** detected value, so `\d{4}` won't unmask a longer number that merely contains four digits.
 
 ## Denylist
 
@@ -114,7 +114,7 @@ masking:
       regex: true
 ```
 
-Patterns are matched literally by default. Set `regex: true` to use JavaScript regular expression syntax, and use single quotes in YAML when the pattern contains backslashes. A regex pattern must not match the empty string (e.g. use `\d+`, not `\d*`); such a pattern is rejected at startup because it would silently mask nothing. Matches that fall inside an already-masked placeholder are ignored.
+Patterns are matched literally by default. Set `regex: true` for JavaScript regex syntax — use single quotes in YAML when the pattern contains backslashes. A regex pattern must not match the empty string (use `\d+`, not `\d*`); empty-matching patterns are rejected at startup because they would mask nothing.
 
 ## Scan Roles
 

--- a/docs/configuration/pii-detection.mdx
+++ b/docs/configuration/pii-detection.mdx
@@ -98,7 +98,7 @@ masking:
       regex: true
 ```
 
-Literal patterns match bidirectionally - detected text containing a whitelist entry (or vice versa) is excluded. Set `regex: true` to match detected text with JavaScript regular expression syntax.
+Literal patterns match bidirectionally - detected text containing a whitelist entry (or vice versa) is excluded. Set `regex: true` to match with JavaScript regular expression syntax; a regex whitelist entry must match the **entire** detected value (so `\d{4}` will not un-mask a longer number that merely contains four digits).
 
 ## Denylist
 
@@ -114,7 +114,9 @@ masking:
       regex: true
 ```
 
-Patterns are matched literally by default. Set `regex: true` to use JavaScript regular expression syntax, and use single quotes in YAML when the pattern contains backslashes.
+Patterns are matched literally by default. Set `regex: true` to use JavaScript regular expression syntax, and use single quotes in YAML when the pattern contains backslashes. A regex pattern must not match the empty string (e.g. use `\d+`, not `\d*`); such a pattern is rejected at startup because it would silently mask nothing. Matches that fall inside an already-masked placeholder are ignored.
+
+<Warning>Whitelist and denylist regexes run against request content on every request. PasteGuard checks that a pattern compiles but does not guard against catastrophic backtracking — use simple, non-backtracking expressions to avoid a denial-of-service from a pathological pattern.</Warning>
 
 ## Scan Roles
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -55,4 +55,55 @@ pii_detection:
       cleanupConfig(path);
     }
   });
+
+  test("accepts masking denylist patterns", () => {
+    const path = writeConfig(`
+mode: mask
+providers:
+  openai: {}
+  anthropic: {}
+masking:
+  denylist:
+    - pattern: "ProjectX"
+      type: PROJECT_NAME
+    - pattern: 'CUST-\\d{6}'
+      type: CUSTOMER_ID
+      regex: true
+pii_detection:
+  detector_url: http://localhost:5002
+`);
+
+    try {
+      const config = loadConfig(path);
+
+      expect(config.masking.denylist).toEqual([
+        { pattern: "ProjectX", type: "PROJECT_NAME", regex: false },
+        { pattern: "CUST-\\d{6}", type: "CUSTOMER_ID", regex: true },
+      ]);
+    } finally {
+      cleanupConfig(path);
+    }
+  });
+
+  test("rejects invalid masking denylist regex patterns", () => {
+    const path = writeConfig(`
+mode: mask
+providers:
+  openai: {}
+  anthropic: {}
+masking:
+  denylist:
+    - pattern: "[ProjectX"
+      type: PROJECT_NAME
+      regex: true
+pii_detection:
+  detector_url: http://localhost:5002
+`);
+
+    try {
+      expect(() => loadConfig(path)).toThrow("Invalid configuration");
+    } finally {
+      cleanupConfig(path);
+    }
+  });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -136,4 +136,26 @@ pii_detection:
       cleanupConfig(path);
     }
   });
+
+  test("rejects denylist regex patterns that match the empty string", () => {
+    const path = writeConfig(`
+mode: mask
+providers:
+  openai: {}
+  anthropic: {}
+masking:
+  denylist:
+    - pattern: 'x*'
+      type: NUM
+      regex: true
+pii_detection:
+  detector_url: http://localhost:5002
+`);
+
+    try {
+      expect(() => loadConfig(path)).toThrow("Invalid configuration");
+    } finally {
+      cleanupConfig(path);
+    }
+  });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -56,13 +56,17 @@ pii_detection:
     }
   });
 
-  test("accepts masking denylist patterns", () => {
+  test("accepts masking whitelist and denylist patterns", () => {
     const path = writeConfig(`
 mode: mask
 providers:
   openai: {}
   anthropic: {}
 masking:
+  whitelist:
+    - "Acme Corp"
+    - pattern: 'TEST-\\d+'
+      regex: true
   denylist:
     - pattern: "ProjectX"
       type: PROJECT_NAME
@@ -76,10 +80,36 @@ pii_detection:
     try {
       const config = loadConfig(path);
 
+      expect(config.masking.whitelist).toEqual([
+        { pattern: "You are Claude Code, Anthropic's official CLI for Claude.", regex: false },
+        { pattern: "Acme Corp", regex: false },
+        { pattern: "TEST-\\d+", regex: true },
+      ]);
       expect(config.masking.denylist).toEqual([
         { pattern: "ProjectX", type: "PROJECT_NAME", regex: false },
         { pattern: "CUST-\\d{6}", type: "CUSTOMER_ID", regex: true },
       ]);
+    } finally {
+      cleanupConfig(path);
+    }
+  });
+
+  test("rejects invalid masking whitelist regex patterns", () => {
+    const path = writeConfig(`
+mode: mask
+providers:
+  openai: {}
+  anthropic: {}
+masking:
+  whitelist:
+    - pattern: "[Acme"
+      regex: true
+pii_detection:
+  detector_url: http://localhost:5002
+`);
+
+    try {
+      expect(() => loadConfig(path)).toThrow("Invalid configuration");
     } finally {
       cleanupConfig(path);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,43 @@ const CodexProviderSchema = z.object({
   base_url: z.string().url().default("https://chatgpt.com/backend-api/codex"),
 });
 
-const DEFAULT_WHITELIST = ["You are Claude Code, Anthropic's official CLI for Claude."];
+const DEFAULT_WHITELIST = [
+  { pattern: "You are Claude Code, Anthropic's official CLI for Claude.", regex: false },
+];
+
+function validateRegexPattern(
+  pattern: string,
+  regex: boolean,
+  ctx: z.RefinementCtx,
+  message: string,
+): void {
+  if (!regex) return;
+
+  try {
+    new RegExp(pattern, "g");
+  } catch {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["pattern"],
+      message,
+    });
+  }
+}
+
+const WhitelistPatternSchema = z.union([
+  z
+    .string()
+    .min(1)
+    .transform((pattern) => ({ pattern, regex: false })),
+  z
+    .object({
+      pattern: z.string().min(1),
+      regex: z.boolean().default(false),
+    })
+    .superRefine((entry, ctx) => {
+      validateRegexPattern(entry.pattern, entry.regex, ctx, "Invalid whitelist regex pattern");
+    }),
+]);
 
 const DenylistPatternSchema = z
   .object({
@@ -39,24 +75,14 @@ const DenylistPatternSchema = z
     regex: z.boolean().default(false),
   })
   .superRefine((entry, ctx) => {
-    if (!entry.regex) return;
-
-    try {
-      new RegExp(entry.pattern, "g");
-    } catch {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["pattern"],
-        message: "Invalid denylist regex pattern",
-      });
-    }
+    validateRegexPattern(entry.pattern, entry.regex, ctx, "Invalid denylist regex pattern");
   });
 
 const MaskingSchema = z.object({
   show_markers: z.boolean().default(false),
   marker_text: z.string().default("[protected]"),
   whitelist: z
-    .array(z.string())
+    .array(WhitelistPatternSchema)
     .default([])
     .transform((arr) => [...DEFAULT_WHITELIST, ...arr]),
   denylist: z.array(DenylistPatternSchema).default([]),
@@ -191,6 +217,7 @@ export type AnthropicProviderConfig = z.infer<typeof AnthropicProviderSchema>;
 export type CodexProviderConfig = z.infer<typeof CodexProviderSchema>;
 export type LocalProviderConfig = z.infer<typeof LocalProviderSchema>;
 export type MaskingConfig = z.infer<typeof MaskingSchema>;
+export type WhitelistPattern = z.infer<typeof WhitelistPatternSchema>;
 export type DenylistPattern = z.infer<typeof DenylistPatternSchema>;
 export type SecretsDetectionConfig = z.infer<typeof SecretsDetectionSchema>;
 export type ServerConfig = z.infer<typeof ServerSchema>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,26 @@ const CodexProviderSchema = z.object({
 
 const DEFAULT_WHITELIST = ["You are Claude Code, Anthropic's official CLI for Claude."];
 
+const DenylistPatternSchema = z
+  .object({
+    pattern: z.string().min(1),
+    type: z.string().min(1),
+    regex: z.boolean().default(false),
+  })
+  .superRefine((entry, ctx) => {
+    if (!entry.regex) return;
+
+    try {
+      new RegExp(entry.pattern, "g");
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["pattern"],
+        message: "Invalid denylist regex pattern",
+      });
+    }
+  });
+
 const MaskingSchema = z.object({
   show_markers: z.boolean().default(false),
   marker_text: z.string().default("[protected]"),
@@ -39,6 +59,7 @@ const MaskingSchema = z.object({
     .array(z.string())
     .default([])
     .transform((arr) => [...DEFAULT_WHITELIST, ...arr]),
+  denylist: z.array(DenylistPatternSchema).default([]),
 });
 
 const LanguageEnum = z.enum(SUPPORTED_LANGUAGES);
@@ -170,6 +191,7 @@ export type AnthropicProviderConfig = z.infer<typeof AnthropicProviderSchema>;
 export type CodexProviderConfig = z.infer<typeof CodexProviderSchema>;
 export type LocalProviderConfig = z.infer<typeof LocalProviderSchema>;
 export type MaskingConfig = z.infer<typeof MaskingSchema>;
+export type DenylistPattern = z.infer<typeof DenylistPatternSchema>;
 export type SecretsDetectionConfig = z.infer<typeof SecretsDetectionSchema>;
 export type ServerConfig = z.infer<typeof ServerSchema>;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,13 +42,24 @@ function validateRegexPattern(
 ): void {
   if (!regex) return;
 
+  let compiled: RegExp;
   try {
-    new RegExp(pattern, "g");
+    compiled = new RegExp(pattern, "g");
   } catch {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["pattern"],
       message,
+    });
+    return;
+  }
+
+  // Reject patterns that match the empty string: zero-length matches are skipped, so they mask nothing.
+  if (compiled.test("")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["pattern"],
+      message: `${message} (must not match the empty string)`,
     });
   }
 }

--- a/src/masking/conflict-resolver.ts
+++ b/src/masking/conflict-resolver.ts
@@ -17,7 +17,7 @@ export interface EntityWithScore extends Span {
   entity_type: string;
 }
 
-function overlaps(a: Span, b: Span): boolean {
+export function overlaps(a: Span, b: Span): boolean {
   return a.start < b.end && b.start < a.end;
 }
 

--- a/src/masking/placeholders.test.ts
+++ b/src/masking/placeholders.test.ts
@@ -84,12 +84,14 @@ describe("findPartialPlaceholderStart", () => {
   });
 
   test("buffers a trailing single bracket (first half of a split [[)", () => {
-    // A chunk ending in "[" may be the first half of "[[" split across chunks,
-    // so it must be buffered, not emitted.
     expect(findPartialPlaceholderStart("Hello [")).toBe(6);
   });
 
   test("buffers a trailing single bracket after a complete placeholder", () => {
     expect(findPartialPlaceholderStart("[[PERSON_1]] [")).toBe(13);
+  });
+
+  test("buffers an incomplete placeholder whose closing ]] is split", () => {
+    expect(findPartialPlaceholderStart("Hi [[PERSON_1]")).toBe(3);
   });
 });

--- a/src/masking/placeholders.test.ts
+++ b/src/masking/placeholders.test.ts
@@ -83,8 +83,13 @@ describe("findPartialPlaceholderStart", () => {
     expect(findPartialPlaceholderStart(text)).toBe(6);
   });
 
-  test("handles text ending with single bracket", () => {
-    // Single [ is not a placeholder start, so should return -1
-    expect(findPartialPlaceholderStart("Hello [")).toBe(-1);
+  test("buffers a trailing single bracket (first half of a split [[)", () => {
+    // A chunk ending in "[" may be the first half of "[[" split across chunks,
+    // so it must be buffered, not emitted.
+    expect(findPartialPlaceholderStart("Hello [")).toBe(6);
+  });
+
+  test("buffers a trailing single bracket after a complete placeholder", () => {
+    expect(findPartialPlaceholderStart("[[PERSON_1]] [")).toBe(13);
   });
 });

--- a/src/masking/placeholders.ts
+++ b/src/masking/placeholders.ts
@@ -35,19 +35,21 @@ export function generateSecretPlaceholder(type: string, count: number): string {
  * Returns the position where it's safe to split, or -1 if entire string is safe
  */
 export function findPartialPlaceholderStart(text: string): number {
-  const placeholderStart = text.lastIndexOf(PLACEHOLDER_DELIMITERS.start);
+  const { start, end } = PLACEHOLDER_DELIMITERS;
+  const placeholderStart = text.lastIndexOf(start);
 
-  if (placeholderStart === -1) {
-    return -1; // No potential placeholder, entire string is safe
+  // An opened "[[" with no closing "]]" after it is an incomplete placeholder.
+  if (placeholderStart !== -1 && !text.slice(placeholderStart).includes(end)) {
+    return placeholderStart;
   }
 
-  // Check if there's a complete placeholder after the last [[
-  const afterStart = text.slice(placeholderStart);
-  const hasCompletePlaceholder = afterStart.includes(PLACEHOLDER_DELIMITERS.end);
-
-  if (hasCompletePlaceholder) {
-    return -1; // Placeholder is complete, entire string is safe
+  // The start delimiter itself can split across chunks (a chunk ending in "[" is
+  // half of "[["), so buffer a trailing partial of it too.
+  for (let n = start.length - 1; n > 0; n--) {
+    if (text.endsWith(start.slice(0, n))) {
+      return text.length - n;
+    }
   }
 
-  return placeholderStart; // Return position where partial placeholder starts
+  return -1; // Entire string is safe to emit
 }

--- a/src/masking/placeholders.ts
+++ b/src/masking/placeholders.ts
@@ -43,12 +43,9 @@ export function findPartialPlaceholderStart(text: string): number {
     return placeholderStart;
   }
 
-  // The start delimiter itself can split across chunks (a chunk ending in "[" is
-  // half of "[["), so buffer a trailing partial of it too.
-  for (let n = start.length - 1; n > 0; n--) {
-    if (text.endsWith(start.slice(0, n))) {
-      return text.length - n;
-    }
+  // A trailing "[" may be the first half of a "[[" that completes in the next chunk.
+  if (text.endsWith(start.slice(0, 1))) {
+    return text.length - 1;
   }
 
   return -1; // Entire string is safe to emit

--- a/src/pii/detect.test.ts
+++ b/src/pii/detect.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { getConfig } from "../config";
 import { openaiExtractor } from "../masking/extractors/openai";
 import type { OpenAIMessage, OpenAIRequest } from "../providers/openai/types";
-import { filterWhitelistedEntities, findDenylistedEntities, PIIDetector } from "./detect";
+import {
+  filterWhitelistedEntities,
+  findDenylistedEntities,
+  mergeDenylistEntities,
+  PIIDetector,
+} from "./detect";
 
 const originalFetch = globalThis.fetch;
 
@@ -211,6 +216,54 @@ describe("PIIDetector", () => {
         config.masking.denylist = previousDenylist;
       }
     });
+
+    test("does not let a denylist substring shrink an overlapping detector entity", async () => {
+      const config = getConfig();
+      const previousDenylist = config.masking.denylist;
+      config.masking.denylist = [{ pattern: "ProjectX", type: "PROJECT_NAME", regex: false }];
+      mockDetector({
+        "ProjectX@corp.com": [{ entity_type: "EMAIL_ADDRESS", start: 6, end: 23, score: 0.95 }],
+      });
+
+      try {
+        const detector = new PIIDetector();
+        const request = createRequest([{ role: "user", content: "Email ProjectX@corp.com" }]);
+
+        const result = await detector.analyzeRequest(request, openaiExtractor);
+
+        expect(result.spanEntities[0]).toEqual([
+          { entity_type: "EMAIL_ADDRESS", start: 6, end: 23, score: 2 },
+        ]);
+      } finally {
+        config.masking.denylist = previousDenylist;
+      }
+    });
+
+    test("skips detection entirely when disabled and no denylist is configured", async () => {
+      const config = getConfig();
+      const previousEnabled = config.pii_detection.enabled;
+      const previousDenylist = config.masking.denylist;
+      config.pii_detection.enabled = false;
+      config.masking.denylist = [];
+      const fetchMock = mock(async () => {
+        throw new Error("Detector should not be called");
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      try {
+        const detector = new PIIDetector();
+        const request = createRequest([{ role: "user", content: "Launch ProjectX" }]);
+
+        const result = await detector.analyzeRequest(request, openaiExtractor);
+
+        expect(result.hasPII).toBe(false);
+        expect(result.spanEntities).toEqual([]);
+        expect(fetchMock).not.toHaveBeenCalled();
+      } finally {
+        config.pii_detection.enabled = previousEnabled;
+        config.masking.denylist = previousDenylist;
+      }
+    });
   });
 
   describe("detectPII", () => {
@@ -315,6 +368,16 @@ describe("PIIDetector", () => {
 
       expect(result).toHaveLength(0);
     });
+
+    test("does not filter when a regex whitelist only partially matches the entity", () => {
+      const text = "card 1234567890123456 end";
+      const entities = [{ entity_type: "CREDIT_CARD", start: 5, end: 21, score: 0.99 }];
+      const whitelist = [{ pattern: "\\d{4}", regex: true }];
+
+      const result = filterWhitelistedEntities(text, entities, whitelist);
+
+      expect(result).toHaveLength(1);
+    });
   });
 
   describe("findDenylistedEntities", () => {
@@ -354,6 +417,59 @@ describe("PIIDetector", () => {
       ]);
 
       expect(result).toEqual([{ entity_type: "CUSTOMER_ID", start: 9, end: 20, score: 2 }]);
+    });
+
+    test("ignores matches that fall inside an existing placeholder", () => {
+      const result = findDenylistedEntities("conn [[CONNECTION_STRING_1]] ProjectX", [
+        { pattern: "\\d+", type: "NUM", regex: true },
+        { pattern: "ProjectX", type: "PROJECT_NAME", regex: false },
+      ]);
+
+      expect(result).toEqual([{ entity_type: "PROJECT_NAME", start: 29, end: 37, score: 2 }]);
+    });
+  });
+
+  describe("mergeDenylistEntities", () => {
+    test("returns detector entities unchanged when there is no denylist", () => {
+      const detected = [{ entity_type: "EMAIL_ADDRESS", start: 0, end: 16, score: 0.9 }];
+
+      expect(mergeDenylistEntities(detected, [])).toBe(detected);
+    });
+
+    test("adds non-overlapping denylist matches", () => {
+      const detected = [{ entity_type: "EMAIL_ADDRESS", start: 0, end: 5, score: 0.9 }];
+      const denylisted = [{ entity_type: "PROJECT_NAME", start: 10, end: 18, score: 2 }];
+
+      expect(mergeDenylistEntities(detected, denylisted)).toEqual([
+        { entity_type: "EMAIL_ADDRESS", start: 0, end: 5, score: 0.9 },
+        { entity_type: "PROJECT_NAME", start: 10, end: 18, score: 2 },
+      ]);
+    });
+
+    test("keeps the full detector span when a denylist match is contained within it", () => {
+      const detected = [{ entity_type: "EMAIL_ADDRESS", start: 0, end: 17, score: 0.95 }];
+      const denylisted = [{ entity_type: "PROJECT_NAME", start: 0, end: 8, score: 2 }];
+
+      expect(mergeDenylistEntities(detected, denylisted)).toEqual([
+        { entity_type: "EMAIL_ADDRESS", start: 0, end: 17, score: 2 },
+      ]);
+    });
+
+    test("unions a partial overlap so no covered region is left unmasked", () => {
+      const detected = [{ entity_type: "PERSON", start: 0, end: 10, score: 0.9 }];
+      const denylisted = [{ entity_type: "PROJECT_NAME", start: 5, end: 15, score: 2 }];
+
+      expect(mergeDenylistEntities(detected, denylisted)).toEqual([
+        { entity_type: "PERSON", start: 0, end: 15, score: 2 },
+      ]);
+    });
+
+    test("returns denylist-only matches when the detector found nothing", () => {
+      const denylisted = [{ entity_type: "PROJECT_NAME", start: 0, end: 8, score: 2 }];
+
+      expect(mergeDenylistEntities([], denylisted)).toEqual([
+        { entity_type: "PROJECT_NAME", start: 0, end: 8, score: 2 },
+      ]);
     });
   });
 });

--- a/src/pii/detect.test.ts
+++ b/src/pii/detect.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { getConfig } from "../config";
 import { openaiExtractor } from "../masking/extractors/openai";
 import type { OpenAIMessage, OpenAIRequest } from "../providers/openai/types";
-import { filterWhitelistedEntities, PIIDetector } from "./detect";
+import { filterWhitelistedEntities, findDenylistedEntities, PIIDetector } from "./detect";
 
 const originalFetch = globalThis.fetch;
 
@@ -164,6 +165,52 @@ describe("PIIDetector", () => {
       // First message (empty string) has no entities
       expect(result.spanEntities[0]).toHaveLength(0);
     });
+
+    test("adds denylist entities when detector returns none", async () => {
+      const config = getConfig();
+      const previousDenylist = config.masking.denylist;
+      config.masking.denylist = [{ pattern: "ProjectX", type: "PROJECT_NAME", regex: false }];
+      mockDetector({});
+
+      try {
+        const detector = new PIIDetector();
+        const request = createRequest([{ role: "user", content: "Launch ProjectX" }]);
+
+        const result = await detector.analyzeRequest(request, openaiExtractor);
+
+        expect(result.hasPII).toBe(true);
+        expect(result.spanEntities[0]).toEqual([
+          { entity_type: "PROJECT_NAME", start: 7, end: 15, score: 2 },
+        ]);
+      } finally {
+        config.masking.denylist = previousDenylist;
+      }
+    });
+
+    test("applies denylist when PII detection is disabled", async () => {
+      const config = getConfig();
+      const previousEnabled = config.pii_detection.enabled;
+      const previousDenylist = config.masking.denylist;
+      config.pii_detection.enabled = false;
+      config.masking.denylist = [{ pattern: "ProjectX", type: "PROJECT_NAME", regex: false }];
+      const fetchMock = mock(async () => {
+        throw new Error("Detector should not be called");
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      try {
+        const detector = new PIIDetector();
+        const request = createRequest([{ role: "user", content: "Launch ProjectX" }]);
+
+        const result = await detector.analyzeRequest(request, openaiExtractor);
+
+        expect(result.hasPII).toBe(true);
+        expect(fetchMock).not.toHaveBeenCalled();
+      } finally {
+        config.pii_detection.enabled = previousEnabled;
+        config.masking.denylist = previousDenylist;
+      }
+    });
   });
 
   describe("detectPII", () => {
@@ -255,6 +302,46 @@ describe("PIIDetector", () => {
       const result = filterWhitelistedEntities(text, entities, []);
 
       expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("findDenylistedEntities", () => {
+    test("finds literal denylist patterns", () => {
+      const result = findDenylistedEntities("ProjectX uses ProjectX-API", [
+        { pattern: "ProjectX", type: "PROJECT_NAME", regex: false },
+      ]);
+
+      expect(result).toEqual([
+        { entity_type: "PROJECT_NAME", start: 0, end: 8, score: 2 },
+        { entity_type: "PROJECT_NAME", start: 14, end: 22, score: 2 },
+      ]);
+    });
+
+    test("finds regex denylist patterns", () => {
+      const result = findDenylistedEntities("Customers CUST-123456 and CUST-654321", [
+        { pattern: "CUST-\\d{6}", type: "CUSTOMER_ID", regex: true },
+      ]);
+
+      expect(result).toEqual([
+        { entity_type: "CUSTOMER_ID", start: 10, end: 21, score: 2 },
+        { entity_type: "CUSTOMER_ID", start: 26, end: 37, score: 2 },
+      ]);
+    });
+
+    test("matches regex syntax literally unless regex is enabled", () => {
+      const result = findDenylistedEntities("Internal [ProjectX", [
+        { pattern: "[ProjectX", type: "PROJECT_NAME", regex: false },
+      ]);
+
+      expect(result).toEqual([{ entity_type: "PROJECT_NAME", start: 9, end: 18, score: 2 }]);
+    });
+
+    test("matches regex patterns containing escaped non-syntax characters", () => {
+      const result = findDenylistedEntities("Customer CUST-123456 onboarded", [
+        { pattern: "CUST\\-\\d{6}", type: "CUSTOMER_ID", regex: true },
+      ]);
+
+      expect(result).toEqual([{ entity_type: "CUSTOMER_ID", start: 9, end: 20, score: 2 }]);
     });
   });
 });

--- a/src/pii/detect.test.ts
+++ b/src/pii/detect.test.ts
@@ -262,7 +262,9 @@ describe("PIIDetector", () => {
     test("filters entities matching whitelist pattern", () => {
       const text = "You are Claude Code, Anthropic's official CLI for Claude.";
       const entities = [{ entity_type: "PERSON", start: 8, end: 14, score: 0.9 }];
-      const whitelist = ["You are Claude Code, Anthropic's official CLI for Claude."];
+      const whitelist = [
+        { pattern: "You are Claude Code, Anthropic's official CLI for Claude.", regex: false },
+      ];
 
       const result = filterWhitelistedEntities(text, entities, whitelist);
 
@@ -275,7 +277,7 @@ describe("PIIDetector", () => {
         { entity_type: "PERSON", start: 8, end: 16, score: 0.9 },
         { entity_type: "EMAIL_ADDRESS", start: 20, end: 36, score: 0.95 },
       ];
-      const whitelist = ["Claude"];
+      const whitelist = [{ pattern: "Claude", regex: false }];
 
       const result = filterWhitelistedEntities(text, entities, whitelist);
 
@@ -285,7 +287,7 @@ describe("PIIDetector", () => {
     test("filters when entity text is contained in whitelist pattern", () => {
       const text = "Hello Claude, how are you?";
       const entities = [{ entity_type: "PERSON", start: 6, end: 12, score: 0.85 }];
-      const whitelist = ["You are Claude Code"];
+      const whitelist = [{ pattern: "You are Claude Code", regex: false }];
 
       const result = filterWhitelistedEntities(text, entities, whitelist);
 
@@ -302,6 +304,16 @@ describe("PIIDetector", () => {
       const result = filterWhitelistedEntities(text, entities, []);
 
       expect(result).toHaveLength(2);
+    });
+
+    test("filters entities matching regex whitelist pattern", () => {
+      const text = "Reference TEST-1234 is public";
+      const entities = [{ entity_type: "CUSTOMER_ID", start: 10, end: 19, score: 0.9 }];
+      const whitelist = [{ pattern: "TEST-\\d+", regex: true }];
+
+      const result = filterWhitelistedEntities(text, entities, whitelist);
+
+      expect(result).toHaveLength(0);
     });
   });
 

--- a/src/pii/detect.test.ts
+++ b/src/pii/detect.test.ts
@@ -185,7 +185,7 @@ describe("PIIDetector", () => {
 
         expect(result.hasPII).toBe(true);
         expect(result.spanEntities[0]).toEqual([
-          { entity_type: "PROJECT_NAME", start: 7, end: 15, score: 2 },
+          { entity_type: "PROJECT_NAME", start: 7, end: 15, score: 1 },
         ]);
       } finally {
         config.masking.denylist = previousDenylist;
@@ -232,7 +232,7 @@ describe("PIIDetector", () => {
         const result = await detector.analyzeRequest(request, openaiExtractor);
 
         expect(result.spanEntities[0]).toEqual([
-          { entity_type: "EMAIL_ADDRESS", start: 6, end: 23, score: 2 },
+          { entity_type: "EMAIL_ADDRESS", start: 6, end: 23, score: 1 },
         ]);
       } finally {
         config.masking.denylist = previousDenylist;
@@ -387,8 +387,8 @@ describe("PIIDetector", () => {
       ]);
 
       expect(result).toEqual([
-        { entity_type: "PROJECT_NAME", start: 0, end: 8, score: 2 },
-        { entity_type: "PROJECT_NAME", start: 14, end: 22, score: 2 },
+        { entity_type: "PROJECT_NAME", start: 0, end: 8, score: 1 },
+        { entity_type: "PROJECT_NAME", start: 14, end: 22, score: 1 },
       ]);
     });
 
@@ -398,8 +398,8 @@ describe("PIIDetector", () => {
       ]);
 
       expect(result).toEqual([
-        { entity_type: "CUSTOMER_ID", start: 10, end: 21, score: 2 },
-        { entity_type: "CUSTOMER_ID", start: 26, end: 37, score: 2 },
+        { entity_type: "CUSTOMER_ID", start: 10, end: 21, score: 1 },
+        { entity_type: "CUSTOMER_ID", start: 26, end: 37, score: 1 },
       ]);
     });
 
@@ -408,7 +408,7 @@ describe("PIIDetector", () => {
         { pattern: "[ProjectX", type: "PROJECT_NAME", regex: false },
       ]);
 
-      expect(result).toEqual([{ entity_type: "PROJECT_NAME", start: 9, end: 18, score: 2 }]);
+      expect(result).toEqual([{ entity_type: "PROJECT_NAME", start: 9, end: 18, score: 1 }]);
     });
 
     test("matches regex patterns containing escaped non-syntax characters", () => {
@@ -416,16 +416,20 @@ describe("PIIDetector", () => {
         { pattern: "CUST\\-\\d{6}", type: "CUSTOMER_ID", regex: true },
       ]);
 
-      expect(result).toEqual([{ entity_type: "CUSTOMER_ID", start: 9, end: 20, score: 2 }]);
+      expect(result).toEqual([{ entity_type: "CUSTOMER_ID", start: 9, end: 20, score: 1 }]);
     });
 
-    test("ignores matches that fall inside an existing placeholder", () => {
-      const result = findDenylistedEntities("conn [[CONNECTION_STRING_1]] ProjectX", [
-        { pattern: "\\d+", type: "NUM", regex: true },
-        { pattern: "ProjectX", type: "PROJECT_NAME", regex: false },
-      ]);
+    test("ignores matches that fall inside a known placeholder", () => {
+      const result = findDenylistedEntities(
+        "conn [[CONNECTION_STRING_1]] ProjectX",
+        [
+          { pattern: "\\d+", type: "NUM", regex: true },
+          { pattern: "ProjectX", type: "PROJECT_NAME", regex: false },
+        ],
+        ["[[CONNECTION_STRING_1]]"],
+      );
 
-      expect(result).toEqual([{ entity_type: "PROJECT_NAME", start: 29, end: 37, score: 2 }]);
+      expect(result).toEqual([{ entity_type: "PROJECT_NAME", start: 29, end: 37, score: 1 }]);
     });
   });
 
@@ -438,37 +442,37 @@ describe("PIIDetector", () => {
 
     test("adds non-overlapping denylist matches", () => {
       const detected = [{ entity_type: "EMAIL_ADDRESS", start: 0, end: 5, score: 0.9 }];
-      const denylisted = [{ entity_type: "PROJECT_NAME", start: 10, end: 18, score: 2 }];
+      const denylisted = [{ entity_type: "PROJECT_NAME", start: 10, end: 18, score: 1 }];
 
       expect(mergeDenylistEntities(detected, denylisted)).toEqual([
         { entity_type: "EMAIL_ADDRESS", start: 0, end: 5, score: 0.9 },
-        { entity_type: "PROJECT_NAME", start: 10, end: 18, score: 2 },
+        { entity_type: "PROJECT_NAME", start: 10, end: 18, score: 1 },
       ]);
     });
 
     test("keeps the full detector span when a denylist match is contained within it", () => {
       const detected = [{ entity_type: "EMAIL_ADDRESS", start: 0, end: 17, score: 0.95 }];
-      const denylisted = [{ entity_type: "PROJECT_NAME", start: 0, end: 8, score: 2 }];
+      const denylisted = [{ entity_type: "PROJECT_NAME", start: 0, end: 8, score: 1 }];
 
       expect(mergeDenylistEntities(detected, denylisted)).toEqual([
-        { entity_type: "EMAIL_ADDRESS", start: 0, end: 17, score: 2 },
+        { entity_type: "EMAIL_ADDRESS", start: 0, end: 17, score: 1 },
       ]);
     });
 
     test("unions a partial overlap so no covered region is left unmasked", () => {
       const detected = [{ entity_type: "PERSON", start: 0, end: 10, score: 0.9 }];
-      const denylisted = [{ entity_type: "PROJECT_NAME", start: 5, end: 15, score: 2 }];
+      const denylisted = [{ entity_type: "PROJECT_NAME", start: 5, end: 15, score: 1 }];
 
       expect(mergeDenylistEntities(detected, denylisted)).toEqual([
-        { entity_type: "PERSON", start: 0, end: 15, score: 2 },
+        { entity_type: "PERSON", start: 0, end: 15, score: 1 },
       ]);
     });
 
     test("returns denylist-only matches when the detector found nothing", () => {
-      const denylisted = [{ entity_type: "PROJECT_NAME", start: 0, end: 8, score: 2 }];
+      const denylisted = [{ entity_type: "PROJECT_NAME", start: 0, end: 8, score: 1 }];
 
       expect(mergeDenylistEntities([], denylisted)).toEqual([
-        { entity_type: "PROJECT_NAME", start: 0, end: 8, score: 2 },
+        { entity_type: "PROJECT_NAME", start: 0, end: 8, score: 1 },
       ]);
     });
   });

--- a/src/pii/detect.ts
+++ b/src/pii/detect.ts
@@ -11,6 +11,9 @@ export interface PIIEntity {
   score: number;
 }
 
+// Denylist matches are exact (operator-configured), so they carry full confidence.
+const DENYLIST_MATCH_SCORE = 1;
+
 function findLiteralMatches(text: string, pattern: string, type: string): PIIEntity[] {
   const matches: PIIEntity[] = [];
   let index = text.indexOf(pattern);
@@ -20,7 +23,7 @@ function findLiteralMatches(text: string, pattern: string, type: string): PIIEnt
       entity_type: type,
       start: index,
       end: index + pattern.length,
-      score: 2,
+      score: DENYLIST_MATCH_SCORE,
     });
     index = text.indexOf(pattern, index + pattern.length);
   }
@@ -38,36 +41,42 @@ function findRegexMatches(text: string, pattern: string, type: string): PIIEntit
       entity_type: type,
       start: match.index,
       end: match.index + match[0].length,
-      score: 2,
+      score: DENYLIST_MATCH_SCORE,
     });
   }
 
   return matches;
 }
 
-// Matches already-masked placeholders such as [[PERSON_1]] or [[API_KEY_SK_2]] (uppercase type + counter).
-const PLACEHOLDER_PATTERN = /\[\[[A-Z][A-Z0-9_]*_\d+\]\]/g;
-
-function placeholderSpans(text: string): Array<{ start: number; end: number }> {
+function placeholderSpans(
+  text: string,
+  placeholders: readonly string[],
+): Array<{ start: number; end: number }> {
   const spans: Array<{ start: number; end: number }> = [];
-  for (const match of text.matchAll(PLACEHOLDER_PATTERN)) {
-    if (match.index !== undefined) {
-      spans.push({ start: match.index, end: match.index + match[0].length });
+  for (const placeholder of placeholders) {
+    let index = text.indexOf(placeholder);
+    while (index !== -1) {
+      spans.push({ start: index, end: index + placeholder.length });
+      index = text.indexOf(placeholder, index + placeholder.length);
     }
   }
   return spans;
 }
 
-export function findDenylistedEntities(text: string, denylist: DenylistPattern[]): PIIEntity[] {
+export function findDenylistedEntities(
+  text: string,
+  denylist: DenylistPattern[],
+  knownPlaceholders: readonly string[] = [],
+): PIIEntity[] {
   if (denylist.length === 0 || !text) return [];
 
   const matches = denylist.flatMap(({ pattern, type, regex }) =>
     regex ? findRegexMatches(text, pattern, type) : findLiteralMatches(text, pattern, type),
   );
-  if (matches.length === 0) return matches;
+  if (matches.length === 0 || knownPlaceholders.length === 0) return matches;
 
-  // Drop matches inside an existing placeholder; re-masking its internals would corrupt the earlier mask.
-  const masked = placeholderSpans(text);
+  // Drop matches inside an already-masked placeholder; re-masking its internals would corrupt the earlier mask.
+  const masked = placeholderSpans(text, knownPlaceholders);
   if (masked.length === 0) return matches;
   return matches.filter((m) => !masked.some((p) => overlaps(m, p)));
 }
@@ -196,6 +205,7 @@ export class PIIDetector {
   async analyzeRequest<TRequest, TResponse>(
     request: TRequest,
     extractor: RequestExtractor<TRequest, TResponse>,
+    knownPlaceholders: readonly string[] = [],
   ): Promise<PIIDetectionResult> {
     const startTime = Date.now();
     const config = getConfig();
@@ -232,7 +242,7 @@ export class PIIDetector {
     const spanEntities: PIIEntity[][] = await Promise.all(
       spans.map(async (span) => {
         if (!span.text) return [];
-        const denylistedEntities = findDenylistedEntities(span.text, denylist);
+        const denylistedEntities = findDenylistedEntities(span.text, denylist, knownPlaceholders);
 
         if (scanRoles && span.role && !scanRoles.has(span.role)) {
           return mergeDenylistEntities([], denylistedEntities);

--- a/src/pii/detect.ts
+++ b/src/pii/detect.ts
@@ -1,4 +1,4 @@
-import { getConfig } from "../config";
+import { type DenylistPattern, getConfig } from "../config";
 import { HEALTH_CHECK_TIMEOUT_MS } from "../constants/timeouts";
 import type { RequestExtractor } from "../masking/types";
 import { getLanguageDetector, type SupportedLanguage } from "../services/language-detector";
@@ -8,6 +8,48 @@ export interface PIIEntity {
   start: number;
   end: number;
   score: number;
+}
+
+function findLiteralMatches(text: string, pattern: string, type: string): PIIEntity[] {
+  const matches: PIIEntity[] = [];
+  let index = text.indexOf(pattern);
+
+  while (index !== -1) {
+    matches.push({
+      entity_type: type,
+      start: index,
+      end: index + pattern.length,
+      score: 2,
+    });
+    index = text.indexOf(pattern, index + pattern.length);
+  }
+
+  return matches;
+}
+
+function findRegexMatches(text: string, pattern: string, type: string): PIIEntity[] {
+  const regex = new RegExp(pattern, "g");
+  const matches: PIIEntity[] = [];
+
+  for (const match of text.matchAll(regex)) {
+    if (match.index === undefined || match[0].length === 0) continue;
+    matches.push({
+      entity_type: type,
+      start: match.index,
+      end: match.index + match[0].length,
+      score: 2,
+    });
+  }
+
+  return matches;
+}
+
+export function findDenylistedEntities(text: string, denylist: DenylistPattern[]): PIIEntity[] {
+  if (denylist.length === 0 || !text) return [];
+
+  return denylist.flatMap(({ pattern, type, regex }) =>
+    regex ? findRegexMatches(text, pattern, type) : findLiteralMatches(text, pattern, type),
+  );
 }
 
 export function filterWhitelistedEntities(
@@ -120,15 +162,22 @@ export class PIIDetector {
       ? new Set(config.pii_detection.scan_roles)
       : null;
     const whitelist = config.masking.whitelist;
+    const denylist = config.masking.denylist;
 
     const spanEntities: PIIEntity[][] = await Promise.all(
       spans.map(async (span) => {
-        if (scanRoles && span.role && !scanRoles.has(span.role)) {
-          return [];
-        }
         if (!span.text) return [];
-        const entities = await this.detectPII(span.text, langResult.language);
-        return filterWhitelistedEntities(span.text, entities, whitelist);
+        const denylistedEntities = findDenylistedEntities(span.text, denylist);
+
+        if (scanRoles && span.role && !scanRoles.has(span.role)) {
+          return denylistedEntities;
+        }
+
+        const detectedEntities = config.pii_detection.enabled
+          ? await this.detectPII(span.text, langResult.language)
+          : [];
+        const filteredEntities = filterWhitelistedEntities(span.text, detectedEntities, whitelist);
+        return [...filteredEntities, ...denylistedEntities];
       }),
     );
 

--- a/src/pii/detect.ts
+++ b/src/pii/detect.ts
@@ -1,5 +1,6 @@
 import { type DenylistPattern, getConfig, type WhitelistPattern } from "../config";
 import { HEALTH_CHECK_TIMEOUT_MS } from "../constants/timeouts";
+import { overlaps, resolveConflicts } from "../masking/conflict-resolver";
 import type { RequestExtractor } from "../masking/types";
 import { getLanguageDetector, type SupportedLanguage } from "../services/language-detector";
 
@@ -44,12 +45,60 @@ function findRegexMatches(text: string, pattern: string, type: string): PIIEntit
   return matches;
 }
 
+// Matches already-masked placeholders such as [[PERSON_1]] or [[API_KEY_SK_2]] (uppercase type + counter).
+const PLACEHOLDER_PATTERN = /\[\[[A-Z][A-Z0-9_]*_\d+\]\]/g;
+
+function placeholderSpans(text: string): Array<{ start: number; end: number }> {
+  const spans: Array<{ start: number; end: number }> = [];
+  for (const match of text.matchAll(PLACEHOLDER_PATTERN)) {
+    if (match.index !== undefined) {
+      spans.push({ start: match.index, end: match.index + match[0].length });
+    }
+  }
+  return spans;
+}
+
 export function findDenylistedEntities(text: string, denylist: DenylistPattern[]): PIIEntity[] {
   if (denylist.length === 0 || !text) return [];
 
-  return denylist.flatMap(({ pattern, type, regex }) =>
+  const matches = denylist.flatMap(({ pattern, type, regex }) =>
     regex ? findRegexMatches(text, pattern, type) : findLiteralMatches(text, pattern, type),
   );
+  if (matches.length === 0) return matches;
+
+  // Drop matches inside an existing placeholder; re-masking its internals would corrupt the earlier mask.
+  const masked = placeholderSpans(text);
+  if (masked.length === 0) return matches;
+  return matches.filter((m) => !masked.some((p) => overlaps(m, p)));
+}
+
+// Additive merge: a denylist match extends coverage but never shrinks an overlapping detector span; overlaps become their union and the detector type wins.
+export function mergeDenylistEntities(detected: PIIEntity[], denylisted: PIIEntity[]): PIIEntity[] {
+  if (denylisted.length === 0) return detected;
+
+  const resolvedDetector = resolveConflicts(detected);
+  const tagged = [
+    ...resolvedDetector.map((e) => ({ e, forced: false })),
+    ...denylisted.map((e) => ({ e, forced: true })),
+  ].sort((a, b) => a.e.start - b.e.start);
+
+  const result: { e: PIIEntity; forced: boolean }[] = [];
+  for (const item of tagged) {
+    const last = result[result.length - 1];
+    if (last && overlaps(item.e, last.e)) {
+      last.e = {
+        entity_type: last.forced && !item.forced ? item.e.entity_type : last.e.entity_type,
+        start: last.e.start,
+        end: Math.max(last.e.end, item.e.end),
+        score: Math.max(last.e.score, item.e.score),
+      };
+      last.forced = last.forced && item.forced;
+    } else {
+      result.push({ e: { ...item.e }, forced: item.forced });
+    }
+  }
+
+  return result.map((r) => r.e);
 }
 
 export function filterWhitelistedEntities(
@@ -63,7 +112,8 @@ export function filterWhitelistedEntities(
     const detectedText = text.slice(entity.start, entity.end);
     return !whitelist.some(({ pattern, regex }) => {
       if (regex) {
-        return new RegExp(pattern, "g").test(detectedText);
+        // Anchor to the whole entity so a partial match can't un-mask a larger detected span.
+        return new RegExp(`^(?:${pattern})$`).test(detectedText);
       }
       return pattern.includes(detectedText) || detectedText.includes(pattern);
     });
@@ -150,6 +200,18 @@ export class PIIDetector {
     const startTime = Date.now();
     const config = getConfig();
 
+    // Pure pass-through: detection off and no denylist, so skip extraction and language detection.
+    if (!config.pii_detection.enabled && config.masking.denylist.length === 0) {
+      return {
+        hasPII: false,
+        spanEntities: [],
+        allEntities: [],
+        scanTimeMs: 0,
+        language: config.pii_detection.fallback_language,
+        languageFallback: true,
+      };
+    }
+
     // Extract all text spans from request
     const spans = extractor.extractTexts(request);
 
@@ -173,14 +235,14 @@ export class PIIDetector {
         const denylistedEntities = findDenylistedEntities(span.text, denylist);
 
         if (scanRoles && span.role && !scanRoles.has(span.role)) {
-          return denylistedEntities;
+          return mergeDenylistEntities([], denylistedEntities);
         }
 
         const detectedEntities = config.pii_detection.enabled
           ? await this.detectPII(span.text, langResult.language)
           : [];
         const filteredEntities = filterWhitelistedEntities(span.text, detectedEntities, whitelist);
-        return [...filteredEntities, ...denylistedEntities];
+        return mergeDenylistEntities(filteredEntities, denylistedEntities);
       }),
     );
 

--- a/src/pii/detect.ts
+++ b/src/pii/detect.ts
@@ -1,4 +1,4 @@
-import { type DenylistPattern, getConfig } from "../config";
+import { type DenylistPattern, getConfig, type WhitelistPattern } from "../config";
 import { HEALTH_CHECK_TIMEOUT_MS } from "../constants/timeouts";
 import type { RequestExtractor } from "../masking/types";
 import { getLanguageDetector, type SupportedLanguage } from "../services/language-detector";
@@ -55,15 +55,18 @@ export function findDenylistedEntities(text: string, denylist: DenylistPattern[]
 export function filterWhitelistedEntities(
   text: string,
   entities: PIIEntity[],
-  whitelist: string[],
+  whitelist: WhitelistPattern[],
 ): PIIEntity[] {
   if (whitelist.length === 0) return entities;
 
   return entities.filter((entity) => {
     const detectedText = text.slice(entity.start, entity.end);
-    return !whitelist.some(
-      (pattern) => pattern.includes(detectedText) || detectedText.includes(pattern),
-    );
+    return !whitelist.some(({ pattern, regex }) => {
+      if (regex) {
+        return new RegExp(pattern, "g").test(detectedText);
+      }
+      return pattern.includes(detectedText) || detectedText.includes(pattern);
+    });
   });
 }
 

--- a/src/pii/mask.test.ts
+++ b/src/pii/mask.test.ts
@@ -18,12 +18,14 @@ const defaultConfig: MaskingConfig = {
   show_markers: false,
   marker_text: "[protected]",
   whitelist: [],
+  denylist: [],
 };
 
 const configWithMarkers: MaskingConfig = {
   show_markers: true,
   marker_text: "[protected]",
   whitelist: [],
+  denylist: [],
 };
 
 /** Helper to create a minimal request from messages */

--- a/src/providers/anthropic/stream-transformer.test.ts
+++ b/src/providers/anthropic/stream-transformer.test.ts
@@ -7,6 +7,7 @@ const defaultConfig: MaskingConfig = {
   show_markers: false,
   marker_text: "[protected]",
   whitelist: [],
+  denylist: [],
 };
 
 /**

--- a/src/providers/openai/stream-transformer.test.ts
+++ b/src/providers/openai/stream-transformer.test.ts
@@ -7,6 +7,7 @@ const defaultConfig: MaskingConfig = {
   show_markers: false,
   marker_text: "[protected]",
   whitelist: [],
+  denylist: [],
 };
 
 /**

--- a/src/providers/openai/stream-transformer.test.ts
+++ b/src/providers/openai/stream-transformer.test.ts
@@ -106,7 +106,6 @@ describe("createUnmaskingStream", () => {
     const context = createMaskingContext();
     context.mapping["[[EMAIL_ADDRESS_1]]"] = "a@b.com";
 
-    // The "[[" delimiter itself is split across the chunk boundary.
     const chunks = [
       `data: {"choices":[{"delta":{"content":"Hello ["}}]}\n\n`,
       `data: {"choices":[{"delta":{"content":"[EMAIL_ADDRESS_1]] world"}}]}\n\n`,
@@ -118,6 +117,23 @@ describe("createUnmaskingStream", () => {
 
     expect(result).toContain("a@b.com");
     expect(result).not.toContain("[[EMAIL_ADDRESS_1]]");
+  });
+
+  test("buffers a placeholder split between the two closing brackets", async () => {
+    const context = createMaskingContext();
+    context.mapping["[[EMAIL_ADDRESS_1]]"] = "a@b.com";
+
+    const chunks = [
+      `data: {"choices":[{"delta":{"content":"Hello [[EMAIL_ADDRESS_1]"}}]}\n\n`,
+      `data: {"choices":[{"delta":{"content":"] world"}}]}\n\n`,
+    ];
+    const source = createSSEStream(chunks);
+
+    const unmaskedStream = createUnmaskingStream(source, context, defaultConfig);
+    const result = await consumeStream(unmaskedStream);
+
+    expect(result).toContain("a@b.com");
+    expect(result).not.toContain("[[EMAIL_ADDRESS_1]");
   });
 
   test("flushes remaining buffer on stream end", async () => {

--- a/src/providers/openai/stream-transformer.test.ts
+++ b/src/providers/openai/stream-transformer.test.ts
@@ -102,6 +102,24 @@ describe("createUnmaskingStream", () => {
     expect(result).toContain("a@b.com");
   });
 
+  test("buffers a placeholder split between the two opening brackets", async () => {
+    const context = createMaskingContext();
+    context.mapping["[[EMAIL_ADDRESS_1]]"] = "a@b.com";
+
+    // The "[[" delimiter itself is split across the chunk boundary.
+    const chunks = [
+      `data: {"choices":[{"delta":{"content":"Hello ["}}]}\n\n`,
+      `data: {"choices":[{"delta":{"content":"[EMAIL_ADDRESS_1]] world"}}]}\n\n`,
+    ];
+    const source = createSSEStream(chunks);
+
+    const unmaskedStream = createUnmaskingStream(source, context, defaultConfig);
+    const result = await consumeStream(unmaskedStream);
+
+    expect(result).toContain("a@b.com");
+    expect(result).not.toContain("[[EMAIL_ADDRESS_1]]");
+  });
+
   test("flushes remaining buffer on stream end", async () => {
     const context = createMaskingContext();
     context.mapping["[[EMAIL_ADDRESS_1]]"] = "test@test.com";

--- a/src/routes/anthropic.ts
+++ b/src/routes/anthropic.ts
@@ -31,7 +31,11 @@ import { callLocalAnthropic } from "../providers/local";
 import { unmaskSecretsResponse } from "../secrets/mask";
 import { logRequest } from "../services/logger";
 import { detectPII, maskPII, type PIIDetectResult } from "../services/pii";
-import { processSecretsRequest, type SecretsProcessResult } from "../services/secrets";
+import {
+  processSecretsRequest,
+  type SecretsProcessResult,
+  secretPlaceholders,
+} from "../services/secrets";
 import {
   createLogData,
   errorFormats,
@@ -113,7 +117,7 @@ anthropicRoutes.post(
     // Step 2: Detect PII and configured denylist terms
     let piiResult: PIIDetectResult;
     try {
-      piiResult = await detectPII(request, anthropicExtractor);
+      piiResult = await detectPII(request, anthropicExtractor, secretPlaceholders(secretsResult));
     } catch (error) {
       console.error("PII detection error:", error);
       return respondDetectionError(c, request, secretsResult, startTime);

--- a/src/routes/anthropic.ts
+++ b/src/routes/anthropic.ts
@@ -110,27 +110,13 @@ anthropicRoutes.post(
       request = secretsResult.request;
     }
 
-    // Step 2: Detect PII (skip if disabled)
+    // Step 2: Detect PII and configured denylist terms
     let piiResult: PIIDetectResult;
-    if (!config.pii_detection.enabled) {
-      piiResult = {
-        detection: {
-          hasPII: false,
-          spanEntities: [],
-          allEntities: [],
-          scanTimeMs: 0,
-          language: "en",
-          languageFallback: false,
-        },
-        hasPII: false,
-      };
-    } else {
-      try {
-        piiResult = await detectPII(request, anthropicExtractor);
-      } catch (error) {
-        console.error("PII detection error:", error);
-        return respondDetectionError(c, request, secretsResult, startTime);
-      }
+    try {
+      piiResult = await detectPII(request, anthropicExtractor);
+    } catch (error) {
+      console.error("PII detection error:", error);
+      return respondDetectionError(c, request, secretsResult, startTime);
     }
 
     // Step 3: Route mode - send to local if PII or secrets detected

--- a/src/routes/api.test.ts
+++ b/src/routes/api.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
-import { filterWhitelistedEntities, findDenylistedEntities, type PIIEntity } from "../pii/detect";
+import {
+  filterWhitelistedEntities,
+  findDenylistedEntities,
+  mergeDenylistEntities,
+  type PIIEntity,
+} from "../pii/detect";
 
 // Mock the PII detector to avoid needing the detector running
 const mockDetectPII = mock<(text: string, language: string) => Promise<PIIEntity[]>>(() =>
@@ -13,6 +18,7 @@ mock.module("../pii/detect", () => ({
   }),
   filterWhitelistedEntities,
   findDenylistedEntities,
+  mergeDenylistEntities,
 }));
 
 // Mock the logger to avoid database operations
@@ -25,6 +31,8 @@ const realConfig = await import("../config");
 const baseConfig = realConfig.getConfig();
 const testConfig = {
   ...baseConfig,
+  // Pin detection on so the detector mock is consumed regardless of config.yaml.
+  pii_detection: { ...baseConfig.pii_detection, enabled: true },
   secrets_detection: {
     ...baseConfig.secrets_detection,
     enabled: true,
@@ -161,6 +169,36 @@ describe("POST /api/mask", () => {
       expect(body.entities).toEqual([
         { type: "PROJECT_NAME", placeholder: "[[PROJECT_NAME_1]]" },
         { type: "CUSTOMER_ID", placeholder: "[[CUSTOMER_ID_1]]" },
+      ]);
+    } finally {
+      testConfig.masking.denylist = previousDenylist;
+    }
+  });
+
+  test("denylist match inside a detected entity does not leak the rest of it", async () => {
+    const previousDenylist = testConfig.masking.denylist;
+    testConfig.masking.denylist = [{ pattern: "ProjectX", type: "PROJECT_NAME", regex: false }];
+    mockDetectPII.mockResolvedValueOnce([
+      { entity_type: "EMAIL_ADDRESS", start: 6, end: 23, score: 0.95 },
+    ]);
+
+    try {
+      const res = await app.request("/api/mask", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "Email ProjectX@corp.com" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        masked: string;
+        context: Record<string, string>;
+        entities: { type: string; placeholder: string }[];
+      };
+      expect(body.masked).toBe("Email [[EMAIL_ADDRESS_1]]");
+      expect(body.context["[[EMAIL_ADDRESS_1]]"]).toBe("ProjectX@corp.com");
+      expect(body.entities).toEqual([
+        { type: "EMAIL_ADDRESS", placeholder: "[[EMAIL_ADDRESS_1]]" },
       ]);
     } finally {
       testConfig.masking.denylist = previousDenylist;
@@ -314,6 +352,36 @@ describe("POST /api/mask", () => {
     expect(body.entities.some((e) => e.type === "CONNECTION_STRING")).toBe(true);
     expect(body.masked).not.toContain("[[EMAIL_ADDRESS");
     expect(body.entities.some((e) => e.type === "EMAIL_ADDRESS")).toBe(false);
+  });
+
+  test("denylist does not corrupt an existing secret placeholder", async () => {
+    const previousDenylist = testConfig.masking.denylist;
+    testConfig.masking.denylist = [{ pattern: "\\d+", type: "NUM", regex: true }];
+    mockDetectPII.mockResolvedValueOnce([]);
+
+    try {
+      const res = await app.request("/api/mask", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: "Connection: postgres://admin:S3cretPass@db.example.com:5432/appdb",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        masked: string;
+        context: Record<string, string>;
+        entities: { type: string }[];
+      };
+      expect(body.masked).toContain("[[CONNECTION_STRING_1]]");
+      expect(body.masked).not.toContain("[[NUM");
+      expect(body.masked).not.toContain("STRING_[[");
+      expect(body.entities.some((e) => e.type === "NUM")).toBe(false);
+      expect(body.context["[[CONNECTION_STRING_1]]"]).toContain("postgres://");
+    } finally {
+      testConfig.masking.denylist = previousDenylist;
+    }
   });
 
   test("returns 400 for malformed JSON", async () => {

--- a/src/routes/api.test.ts
+++ b/src/routes/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
-import { filterWhitelistedEntities, type PIIEntity } from "../pii/detect";
+import { filterWhitelistedEntities, findDenylistedEntities, type PIIEntity } from "../pii/detect";
 
 // Mock the PII detector to avoid needing the detector running
 const mockDetectPII = mock<(text: string, language: string) => Promise<PIIEntity[]>>(() =>
@@ -12,6 +12,7 @@ mock.module("../pii/detect", () => ({
     healthCheck: mock(() => Promise.resolve(true)),
   }),
   filterWhitelistedEntities,
+  findDenylistedEntities,
 }));
 
 // Mock the logger to avoid database operations
@@ -131,6 +132,39 @@ describe("POST /api/mask", () => {
     expect(body.counters.EMAIL_ADDRESS).toBe(1);
     expect(body.entities).toHaveLength(1);
     expect(body.entities[0].type).toBe("EMAIL_ADDRESS");
+  });
+
+  test("masks configured denylist patterns", async () => {
+    const previousDenylist = testConfig.masking.denylist;
+    testConfig.masking.denylist = [
+      { pattern: "ProjectX", type: "PROJECT_NAME", regex: false },
+      { pattern: "CUST-\\d{6}", type: "CUSTOMER_ID", regex: true },
+    ];
+    mockDetectPII.mockResolvedValueOnce([]);
+
+    try {
+      const res = await app.request("/api/mask", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "ProjectX customer CUST-123456" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        masked: string;
+        context: Record<string, string>;
+        entities: { type: string; placeholder: string }[];
+      };
+      expect(body.masked).toBe("[[PROJECT_NAME_1]] customer [[CUSTOMER_ID_1]]");
+      expect(body.context["[[PROJECT_NAME_1]]"]).toBe("ProjectX");
+      expect(body.context["[[CUSTOMER_ID_1]]"]).toBe("CUST-123456");
+      expect(body.entities).toEqual([
+        { type: "PROJECT_NAME", placeholder: "[[PROJECT_NAME_1]]" },
+        { type: "CUSTOMER_ID", placeholder: "[[CUSTOMER_ID_1]]" },
+      ]);
+    } finally {
+      testConfig.masking.denylist = previousDenylist;
+    }
   });
 
   test("respects startFrom counters", async () => {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -9,7 +9,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { getConfig, type SecretsDetectionConfig } from "../config";
 import { createPlaceholderContext, type PlaceholderContext } from "../masking/context";
-import { filterWhitelistedEntities, getPIIDetector } from "../pii/detect";
+import { filterWhitelistedEntities, findDenylistedEntities, getPIIDetector } from "../pii/detect";
 import { mask as maskPII } from "../pii/mask";
 import { detectSecrets } from "../secrets/detect";
 import { maskSecrets } from "../secrets/mask";
@@ -198,7 +198,9 @@ apiRoutes.post("/mask", async (c) => {
     try {
       const piiStartTime = Date.now();
       const detector = getPIIDetector();
-      const piiEntities = await detector.detectPII(maskedText, language);
+      const piiEntities = config.pii_detection.enabled
+        ? await detector.detectPII(maskedText, language)
+        : [];
       scanTimeMs = Date.now() - piiStartTime;
 
       // Apply whitelist filtering
@@ -207,15 +209,19 @@ apiRoutes.post("/mask", async (c) => {
         piiEntities,
         config.masking.whitelist,
       );
+      const entitiesToMask = [
+        ...filteredEntities,
+        ...findDenylistedEntities(maskedText, config.masking.denylist),
+      ];
 
       // Capture counters before masking to track new entities
       const countersBefore = { ...context.counters };
-      const piiResult = maskPII(maskedText, filteredEntities, context);
+      const piiResult = maskPII(maskedText, entitiesToMask, context);
       maskedText = piiResult.masked;
       allEntities.push(...extractEntities(countersBefore, piiResult.context));
 
       // Collect unique entity types for logging
-      for (const entity of filteredEntities) {
+      for (const entity of entitiesToMask) {
         if (!piiEntityTypes.includes(entity.entity_type)) {
           piiEntityTypes.push(entity.entity_type);
         }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -216,7 +216,7 @@ apiRoutes.post("/mask", async (c) => {
       );
       const entitiesToMask = mergeDenylistEntities(
         filteredEntities,
-        findDenylistedEntities(maskedText, config.masking.denylist),
+        findDenylistedEntities(maskedText, config.masking.denylist, Object.keys(context.mapping)),
       );
 
       // Capture counters before masking to track new entities

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -9,7 +9,12 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { getConfig, type SecretsDetectionConfig } from "../config";
 import { createPlaceholderContext, type PlaceholderContext } from "../masking/context";
-import { filterWhitelistedEntities, findDenylistedEntities, getPIIDetector } from "../pii/detect";
+import {
+  filterWhitelistedEntities,
+  findDenylistedEntities,
+  getPIIDetector,
+  mergeDenylistEntities,
+} from "../pii/detect";
 import { mask as maskPII } from "../pii/mask";
 import { detectSecrets } from "../secrets/detect";
 import { maskSecrets } from "../secrets/mask";
@@ -209,10 +214,10 @@ apiRoutes.post("/mask", async (c) => {
         piiEntities,
         config.masking.whitelist,
       );
-      const entitiesToMask = [
-        ...filteredEntities,
-        ...findDenylistedEntities(maskedText, config.masking.denylist),
-      ];
+      const entitiesToMask = mergeDenylistEntities(
+        filteredEntities,
+        findDenylistedEntities(maskedText, config.masking.denylist),
+      );
 
       // Capture counters before masking to track new entities
       const countersBefore = { ...context.counters };

--- a/src/routes/codex.ts
+++ b/src/routes/codex.ts
@@ -81,25 +81,11 @@ codexRoutes.post(
     }
 
     let piiResult: PIIDetectResult;
-    if (!config.pii_detection.enabled) {
-      piiResult = {
-        detection: {
-          hasPII: false,
-          spanEntities: [],
-          allEntities: [],
-          scanTimeMs: 0,
-          language: config.pii_detection.fallback_language,
-          languageFallback: false,
-        },
-        hasPII: false,
-      };
-    } else {
-      try {
-        piiResult = await detectPII(request, codexExtractor);
-      } catch (error) {
-        console.error("PII detection error:", error);
-        return respondDetectionError(c, request, startTime);
-      }
+    try {
+      piiResult = await detectPII(request, codexExtractor);
+    } catch (error) {
+      console.error("PII detection error:", error);
+      return respondDetectionError(c, request, startTime);
     }
 
     const shouldBlockRouteMode =

--- a/src/routes/codex.ts
+++ b/src/routes/codex.ts
@@ -23,7 +23,11 @@ import {
 } from "../secrets/mask";
 import { logRequest } from "../services/logger";
 import { detectPII, maskPII, type PIIDetectResult } from "../services/pii";
-import { processSecretsRequest, type SecretsProcessResult } from "../services/secrets";
+import {
+  processSecretsRequest,
+  type SecretsProcessResult,
+  secretPlaceholders,
+} from "../services/secrets";
 import {
   createLogData,
   errorFormats,
@@ -82,7 +86,7 @@ codexRoutes.post(
 
     let piiResult: PIIDetectResult;
     try {
-      piiResult = await detectPII(request, codexExtractor);
+      piiResult = await detectPII(request, codexExtractor, secretPlaceholders(secretsResult));
     } catch (error) {
       console.error("PII detection error:", error);
       return respondDetectionError(c, request, startTime);

--- a/src/routes/openai.ts
+++ b/src/routes/openai.ts
@@ -31,7 +31,11 @@ import {
 import { unmaskSecretsResponse } from "../secrets/mask";
 import { logRequest } from "../services/logger";
 import { detectPII, maskPII, type PIIDetectResult } from "../services/pii";
-import { processSecretsRequest, type SecretsProcessResult } from "../services/secrets";
+import {
+  processSecretsRequest,
+  type SecretsProcessResult,
+  secretPlaceholders,
+} from "../services/secrets";
 import { extractTextContent } from "../utils/content";
 import {
   createLogData,
@@ -83,7 +87,7 @@ openaiRoutes.post(
     // Step 2: Detect PII and configured denylist terms
     let piiResult: PIIDetectResult;
     try {
-      piiResult = await detectPII(request, openaiExtractor);
+      piiResult = await detectPII(request, openaiExtractor, secretPlaceholders(secretsResult));
     } catch (error) {
       console.error("PII detection error:", error);
       return respondDetectionError(c, request, startTime);

--- a/src/routes/openai.ts
+++ b/src/routes/openai.ts
@@ -80,27 +80,13 @@ openaiRoutes.post(
       request = secretsResult.request;
     }
 
-    // Step 2: Detect PII (skip if disabled)
+    // Step 2: Detect PII and configured denylist terms
     let piiResult: PIIDetectResult;
-    if (!config.pii_detection.enabled) {
-      piiResult = {
-        detection: {
-          hasPII: false,
-          spanEntities: [],
-          allEntities: [],
-          scanTimeMs: 0,
-          language: "en",
-          languageFallback: false,
-        },
-        hasPII: false,
-      };
-    } else {
-      try {
-        piiResult = await detectPII(request, openaiExtractor);
-      } catch (error) {
-        console.error("PII detection error:", error);
-        return respondDetectionError(c, request, startTime);
-      }
+    try {
+      piiResult = await detectPII(request, openaiExtractor);
+    } catch (error) {
+      console.error("PII detection error:", error);
+      return respondDetectionError(c, request, startTime);
     }
 
     // Step 3: Process based on mode

--- a/src/services/pii.ts
+++ b/src/services/pii.ts
@@ -23,9 +23,10 @@ export interface PIIMaskResult<TRequest> {
 export async function detectPII<TRequest, TResponse>(
   request: TRequest,
   extractor: RequestExtractor<TRequest, TResponse>,
+  knownPlaceholders: readonly string[] = [],
 ): Promise<PIIDetectResult> {
   const detector = getPIIDetector();
-  const detection = await detector.analyzeRequest(request, extractor);
+  const detection = await detector.analyzeRequest(request, extractor, knownPlaceholders);
 
   return {
     detection,

--- a/src/services/pii.ts
+++ b/src/services/pii.ts
@@ -23,7 +23,8 @@ export interface PIIMaskResult<TRequest> {
 export async function detectPII<TRequest, TResponse>(
   request: TRequest,
   extractor: RequestExtractor<TRequest, TResponse>,
-  knownPlaceholders: readonly string[] = [],
+  // Required (no default) so a new route can't silently skip the secrets placeholders.
+  knownPlaceholders: readonly string[],
 ): Promise<PIIDetectResult> {
   const detector = getPIIDetector();
   const detection = await detector.analyzeRequest(request, extractor, knownPlaceholders);

--- a/src/services/secrets.ts
+++ b/src/services/secrets.ts
@@ -18,6 +18,11 @@ export interface SecretsProcessResult<TRequest> {
   masked: boolean;
 }
 
+/** Placeholder strings already inserted by secrets masking (so later PII/denylist passes skip them). */
+export function secretPlaceholders<TRequest>(result: SecretsProcessResult<TRequest>): string[] {
+  return result.maskingContext ? Object.keys(result.maskingContext.mapping) : [];
+}
+
 /**
  * Process a request for secrets detection
  */


### PR DESCRIPTION
## Summary

Implements a configurable masking **denylist**: force-mask specific literal or regex patterns with an operator-chosen placeholder type, even when the detector doesn't flag them or PII detection is disabled. Also adds regex support to the existing `masking.whitelist`.

Closes #59.

## Behavior

**Denylist** (`masking.denylist`) — each entry is `{ pattern, type, regex? }`:
- Matched literally by default; set `regex: true` for JavaScript regular-expression syntax.
- Applied additively — a denylist match never shrinks a detector entity's coverage (overlaps are unioned).
- Matches that fall inside an already-masked placeholder are skipped, so a denylist pattern can't corrupt an existing secret/PII placeholder. `detectPII` now requires the set of known placeholders so a route can't silently skip this.
- Regex patterns that match the empty string are rejected at config load.

**Whitelist** — entries may now be `{ pattern, regex? }`. A regex whitelist entry must match the **entire** detected value, so a partial match can't un-mask a larger entity (e.g. `\d{4}` won't un-mask a full card number).

## Fixes

- **Streaming unmask:** a placeholder whose `[[`/`]]` delimiter is split across SSE chunks is now buffered and restored correctly, instead of the raw placeholder leaking to the client.

## Docs

- Updated mask-mode and PII-detection docs with denylist/whitelist examples and semantics.

## Testing

- Unit tests for config parsing, denylist/whitelist matching, placeholder buffering, and the `/api/mask` route.
- End-to-end verification against the all-in-one Docker image across the OpenAI, Anthropic, and Codex routes (non-streaming and streaming, including delimiter-split chunks), plus a config matrix: mask / route / detection-disabled / show_markers / whitelist / secrets-block.
