### PR TITLE
Fix for metadata chunk processing in OpenAi-API providers using streaming mode

### DIFF
--- a/src/providers/openai/stream-transformer.ts
+++ b/src/providers/openai/stream-transformer.ts
@@ -120,7 +120,7 @@ export function createUnmaskingStream(
                 const parsed = JSON.parse(data);
                 const content = parsed.choices?.[0]?.delta?.content;
 
-                if (typeof content === "string") {
+                if (typeof content === "string" && content !== "") {
                   const unmasked = unmaskTextContent(
                     content,
                     piiBuffer,


### PR DESCRIPTION
What
----  
Fix handling of empty‑content (empty strings - "") chunks in OpenAI API support - in streaming mode.

Why
----  
Some providers send a single chunk with an empty string for metadata, causing the info (e.g., usage) to be ignored right now (processed as response text to be processed and then filtered out).

Suggested tests  
----
- Simulate a provider response with an empty‑content chunk and verify metadata is returned - Personally verified a few times against numerous providers. 
- Ensure normal streaming responses still work unchanged - According to my tests nothing has changed for the worse in that regard (normal operation).