### PR TITLE
Redirect root path to dashboard or health

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Run PasteGuard as a local proxy:
 docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:latest
 ```
 
+Open [localhost:3000](http://localhost:3000) for the dashboard.
+
 Point your tools or app to PasteGuard instead of the provider:
 
 | Target | PasteGuard URL | Original URL |
@@ -113,7 +115,7 @@ Every request is logged with masking details. See what was detected, what was ma
 
 <img src="assets/dashboard.png" width="100%" alt="PasteGuard Dashboard">
 
-[localhost:3000/dashboard](http://localhost:3000/dashboard)
+[localhost:3000](http://localhost:3000)
 
 ## What it catches
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -29,7 +29,7 @@ docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:latest
 ```
 
 PasteGuard runs on `http://localhost:3000`. Open
-[http://localhost:3000/dashboard](http://localhost:3000/dashboard) for the dashboard.
+[http://localhost:3000](http://localhost:3000) for the dashboard.
 
 <Note>
 The first start loads the detection model and can take a little longer; the

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -9,7 +9,7 @@ description: Run PasteGuard as a local proxy
 docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:latest
 ```
 
-PasteGuard runs on `http://localhost:3000`. Open `http://localhost:3000/dashboard` to see the dashboard.
+PasteGuard runs on `http://localhost:3000`. Open `http://localhost:3000` to see the dashboard.
 
 <Note>
 For custom configuration or persistent logs, see [Installation](/installation).
@@ -46,7 +46,7 @@ The name and email were masked before reaching OpenAI and restored in the respon
 
 ## 4. View Dashboard
 
-Open `http://localhost:3000/dashboard` in your browser to see:
+Open `http://localhost:3000` in your browser to see:
 
 - Request history
 - Detected PII entities

--- a/src/routes/health.test.ts
+++ b/src/routes/health.test.ts
@@ -1,9 +1,37 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { Hono } from "hono";
+import { getConfig } from "../config";
 import { healthRoutes } from "./health";
 
 const app = new Hono();
 app.route("/", healthRoutes);
+
+const config = getConfig();
+const originalDashboardEnabled = config.dashboard.enabled;
+
+afterEach(() => {
+  config.dashboard.enabled = originalDashboardEnabled;
+});
+
+describe("GET /", () => {
+  test("redirects to dashboard when dashboard is enabled", async () => {
+    config.dashboard.enabled = true;
+
+    const res = await app.request("/");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/dashboard");
+  });
+
+  test("redirects to health when dashboard is disabled", async () => {
+    config.dashboard.enabled = false;
+
+    const res = await app.request("/");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/health");
+  });
+});
 
 describe("GET /health", () => {
   test("returns health status", async () => {

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -5,6 +5,11 @@ import { healthCheck as checkDetector } from "../services/pii";
 
 export const healthRoutes = new Hono();
 
+healthRoutes.get("/", (c) => {
+  const config = getConfig();
+  return c.redirect(config.dashboard.enabled ? "/dashboard" : "/health");
+});
+
 healthRoutes.get("/health", async (c) => {
   const config = getConfig();
   const piiEnabled = config.pii_detection.enabled;


### PR DESCRIPTION
Adds a `/` route that redirects to `/dashboard` when the dashboard is enabled, otherwise to `/health` (which is always mounted). README and docs are updated to point users at the root URL instead of `/dashboard`, and tests cover both redirect branches. Verified with `bun test`, `bun run typecheck`, and `bun run check`.