### PR TITLE
Enable all secret detectors by default

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,36 +119,18 @@ secrets_detection:
   #   route_local:  Route to local provider (only works in route mode)
   action: mask
 
-  # Secret types to detect
-  # Private Keys (enabled by default):
-  #   - OPENSSH_PRIVATE_KEY: OpenSSH format (-----BEGIN OPENSSH PRIVATE KEY-----)
-  #   - PEM_PRIVATE_KEY:     PEM formats (RSA, PRIVATE KEY, ENCRYPTED PRIVATE KEY)
-  #
-  # API Keys (opt-in):
-  #   - API_KEY_SK:          Secret keys with sk- or sk_ prefix (OpenAI, Anthropic, Stripe, RevenueCat)
-  #   - API_KEY_AWS:         AWS Access Keys (AKIA...)
-  #   - API_KEY_GITHUB:      GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_)
-  #
-  # Tokens (opt-in):
-  #   - JWT_TOKEN:           JSON Web Tokens (eyJ...)
-  #   - BEARER_TOKEN:        Bearer tokens in Authorization-style contexts
-  #
-  # Environment Variables (opt-in):
-  #   - ENV_PASSWORD:        DB_PASSWORD=..., ADMIN_PWD=... (8+ char values)
-  #   - ENV_SECRET:          APP_SECRET=..., JWT_SECRET=... (8+ char values)
-  #   - CONNECTION_STRING:   postgres://user:pass@host, mongodb://...
+  # All supported secret types are enabled by default. Remove entries to narrow detection.
   entities:
     - OPENSSH_PRIVATE_KEY
     - PEM_PRIVATE_KEY
-    # Uncomment to detect API keys and tokens:
-    # - API_KEY_SK
-    # - API_KEY_AWS
-    # - API_KEY_GITHUB
-    # - JWT_TOKEN
-    # - BEARER_TOKEN
-    # - ENV_PASSWORD
-    # - ENV_SECRET
-    # - CONNECTION_STRING
+    - API_KEY_SK
+    - API_KEY_AWS
+    - API_KEY_GITHUB
+    - JWT_TOKEN
+    - BEARER_TOKEN
+    - ENV_PASSWORD
+    - ENV_SECRET
+    - CONNECTION_STRING
 
   # Maximum characters to scan per request (performance limit)
   # Note: Secrets placed after this limit won't be detected.

--- a/docs/api-reference/status.mdx
+++ b/docs/api-reference/status.mdx
@@ -89,7 +89,18 @@ curl http://localhost:3000/info
   "secrets_detection": {
     "enabled": true,
     "action": "mask",
-    "entities": ["OPENSSH_PRIVATE_KEY", "PEM_PRIVATE_KEY"],
+    "entities": [
+      "OPENSSH_PRIVATE_KEY",
+      "PEM_PRIVATE_KEY",
+      "API_KEY_SK",
+      "API_KEY_AWS",
+      "API_KEY_GITHUB",
+      "JWT_TOKEN",
+      "BEARER_TOKEN",
+      "ENV_PASSWORD",
+      "ENV_SECRET",
+      "CONNECTION_STRING"
+    ],
     "max_scan_chars": 200000,
     "log_detected_types": true
   },

--- a/docs/concepts/secrets-detection.mdx
+++ b/docs/concepts/secrets-detection.mdx
@@ -7,14 +7,16 @@ PasteGuard detects secrets before PII detection and can block, mask, or route re
 
 ## Supported Secret Types
 
-### Private Keys (enabled by default)
+All supported secret types are enabled by default.
+
+### Private Keys
 
 | Type | Pattern |
 |------|---------|
 | `OPENSSH_PRIVATE_KEY` | `-----BEGIN OPENSSH PRIVATE KEY-----` |
 | `PEM_PRIVATE_KEY` | `-----BEGIN RSA PRIVATE KEY-----`, etc. |
 
-### API Keys (opt-in)
+### API Keys
 
 | Type | Pattern |
 |------|---------|
@@ -22,14 +24,14 @@ PasteGuard detects secrets before PII detection and can block, mask, or route re
 | `API_KEY_AWS` | `AKIA...` (20 chars) |
 | `API_KEY_GITHUB` | `ghp_...`, `gho_...`, `ghu_...`, `ghs_...`, `ghr_...` (40+ chars) |
 
-### Tokens (opt-in)
+### Tokens
 
 | Type | Pattern |
 |------|---------|
 | `JWT_TOKEN` | `eyJ...` (three base64 segments) |
 | `BEARER_TOKEN` | `Bearer ...` (40+ char tokens) |
 
-### Environment Variables (opt-in)
+### Environment Variables
 
 | Type | Pattern |
 |------|---------|

--- a/docs/configuration/secrets-detection.mdx
+++ b/docs/configuration/secrets-detection.mdx
@@ -10,6 +10,14 @@ secrets_detection:
   entities:
     - OPENSSH_PRIVATE_KEY
     - PEM_PRIVATE_KEY
+    - API_KEY_SK
+    - API_KEY_AWS
+    - API_KEY_GITHUB
+    - JWT_TOKEN
+    - BEARER_TOKEN
+    - ENV_PASSWORD
+    - ENV_SECRET
+    - CONNECTION_STRING
   max_scan_chars: 200000
   log_detected_types: true
 ```
@@ -20,7 +28,7 @@ secrets_detection:
 |--------|---------|-------------|
 | `enabled` | `true` | Enable secrets detection |
 | `action` | `mask` | Action when secrets found |
-| `entities` | Private keys | Secret types to detect |
+| `entities` | All supported types | Secret types to detect |
 | `max_scan_chars` | `200000` | Max characters to scan (0 = unlimited) |
 | `log_detected_types` | `true` | Log detected types (never logs content) |
 
@@ -56,7 +64,10 @@ secrets_detection:
 
 ## Secret Types
 
-### Private Keys (enabled by default)
+All supported secret types are enabled by default. Set `entities` to a smaller
+list if you want to scan only specific categories.
+
+### Private Keys
 
 ```yaml
 secrets_detection:
@@ -65,7 +76,7 @@ secrets_detection:
     - PEM_PRIVATE_KEY      # RSA, PRIVATE KEY, ENCRYPTED PRIVATE KEY
 ```
 
-### API Keys (opt-in)
+### API Keys
 
 ```yaml
 secrets_detection:
@@ -75,7 +86,7 @@ secrets_detection:
     - API_KEY_GITHUB   # ghp_, gho_, ghu_, ghs_, ghr_ (40+ chars)
 ```
 
-### Tokens (opt-in)
+### Tokens
 
 ```yaml
 secrets_detection:
@@ -84,7 +95,7 @@ secrets_detection:
     - BEARER_TOKEN   # Bearer ... (40+ char tokens)
 ```
 
-### Environment Variables (opt-in)
+### Environment Variables
 
 ```yaml
 secrets_detection:

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -56,6 +56,36 @@ pii_detection:
     }
   });
 
+  test("enables all supported secret entity types by default", () => {
+    const path = writeConfig(`
+mode: mask
+providers:
+  openai: {}
+  anthropic: {}
+pii_detection:
+  detector_url: http://localhost:5002
+`);
+
+    try {
+      const config = loadConfig(path);
+
+      expect(config.secrets_detection.entities).toEqual([
+        "OPENSSH_PRIVATE_KEY",
+        "PEM_PRIVATE_KEY",
+        "API_KEY_SK",
+        "API_KEY_AWS",
+        "API_KEY_GITHUB",
+        "JWT_TOKEN",
+        "BEARER_TOKEN",
+        "ENV_PASSWORD",
+        "ENV_SECRET",
+        "CONNECTION_STRING",
+      ]);
+    } finally {
+      cleanupConfig(path);
+    }
+  });
+
   test("accepts masking allowlist and denylist patterns", () => {
     const path = writeConfig(`
 mode: mask

--- a/src/config.ts
+++ b/src/config.ts
@@ -172,7 +172,7 @@ const SecretEntityTypes = [
 const SecretsDetectionSchema = z.object({
   enabled: z.boolean().default(true),
   action: z.enum(["block", "mask", "route_local"]).default("mask"),
-  entities: z.array(z.enum(SecretEntityTypes)).default(["OPENSSH_PRIVATE_KEY", "PEM_PRIVATE_KEY"]),
+  entities: z.array(z.enum(SecretEntityTypes)).default([...SecretEntityTypes]),
   max_scan_chars: z.coerce.number().int().min(0).default(200000),
   log_detected_types: z.boolean().default(true),
   scan_roles: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

- Enable every supported secret detector by default instead of only private keys.
- Update the example config and docs so API keys, tokens, env credentials, and connection strings are no longer described as opt-in.
- Add a config regression test for the default secret entity list.

## Validation

- `bun test`
- `bun run typecheck`
- `bun run check`
- `git diff --check`
- Docker all-in-one image built locally and tested on `localhost:3020`.
- Docker deep probe: `38/38` passed, covering `/health`, `/info`, dashboard APIs, `/api/mask`, all default secret types, live PII detector masking, and provider-route validation.

## Notes

Real upstream OpenAI/Anthropic/Codex forwarding was not tested because the test container did not have provider credentials or a ChatGPT session.