### PR TITLE
Stop seeding config.yaml into new Conductor workspaces

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,7 +1,5 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
-file_include_globs = ".env\n.env.local\n.env.*.local\nconfig.yaml\n"
-
 [scripts]
 setup = """
 set -e


### PR DESCRIPTION
Removes file_include_globs from the Conductor repo settings so each new workspace regenerates config.yaml from config.example.yaml in setup rather than inheriting a stale copy. The inherited copy carried a fixed detector_url that didn't match the per-workspace detector port, leaving the proxy pointed at the wrong detector; regenerating keeps the ${DETECTOR_URL} placeholder that resolves correctly per workspace. The only remaining globs covered an empty .env, so the setting is dropped entirely. Verified by simulating the setup+run flow: a freshly regenerated config resolves both the server port and detector_url from the injected env vars, with correct fallbacks when unset.