### PR TITLE
Tune GLiNER confidence floors

### DIFF
--- a/detector/detector/gliner_layer.py
+++ b/detector/detector/gliner_layer.py
@@ -26,11 +26,11 @@ def _floor(label: str, default: float) -> float:
 # overridable via env, e.g. DETECTOR_FLOOR_LOCATION=0.6). Role nouns are demoted
 # by the suppressor labels (below), not by this floor.
 PER_LABEL_FLOOR = {
-    "person": _floor("person", 0.85),
-    "location": _floor("location", 0.50),
+    "person": _floor("person", 0.95),
+    "location": _floor("location", 0.80),
     # A dedicated "address" label recovers full street addresses that a bare
     # "location" reading misses; emitted as LOCATION (see _LABEL_TO_TYPE).
-    "address": _floor("address", 0.70),
+    "address": _floor("address", 0.80),
 }
 # Labels the request `score_threshold` may raise (high-volume, deployment-tunable).
 _TUNABLE = {"person", "location", "address"}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,8 @@ FROM python:3.11-slim AS detector
 # pin it for every arch. (PyPI's DEFAULT index now ships CUDA builds for
 # linux/arm64 too — e.g. torch 2.x+cuXXX — which would drag ~6 GB of unused
 # CUDA libraries into the image; the explicit CPU index avoids that.)
-RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir typing-extensions \
+    && pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
 
 # Install the detector package (pulls fastapi/uvicorn/gliner/stdnum/...).
 COPY detector/pyproject.toml /srv/detector/


### PR DESCRIPTION
Raises the default GLiNER confidence floors for person, location, and address labels to reduce report-only precision false positives while keeping recall unchanged in the accuracy benchmark.

The change keeps the existing environment overrides intact.

Verified with `bun run benchmark:accuracy --url http://127.0.0.1:8765/analyze --verbose`, `uv run --python 3.12 pytest`, `bun test`, `bun run typecheck`, and `bun run check`.
