### PR TITLE
Update tested integration docs

### DIFF
--- a/docs/api-reference/anthropic.mdx
+++ b/docs/api-reference/anthropic.mdx
@@ -21,7 +21,7 @@ curl http://localhost:3000/anthropic/v1/messages \
   -H "anthropic-version: 2023-06-01" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-4-6",
     "max_tokens": 1024,
     "messages": [
       {"role": "user", "content": "Hello"}
@@ -33,7 +33,7 @@ curl http://localhost:3000/anthropic/v1/messages \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `model` | string | Yes | Model ID (e.g., `claude-sonnet-4-20250514`) |
+| `model` | string | Yes | Model ID (e.g., `claude-sonnet-4-6`) |
 | `messages` | array | Yes | Conversation messages |
 | `max_tokens` | number | Yes | Maximum tokens to generate |
 | `stream` | boolean | No | Enable streaming |
@@ -49,7 +49,7 @@ All [Anthropic Messages API](https://platform.claude.com/docs/en/api/messages) p
   "id": "msg_abc123",
   "type": "message",
   "role": "assistant",
-  "model": "claude-sonnet-4-20250514",
+  "model": "claude-sonnet-4-6",
   "content": [
     {
       "type": "text",
@@ -76,7 +76,7 @@ from anthropic import Anthropic
 client = Anthropic(base_url="http://localhost:3000/anthropic")
 
 with client.messages.stream(
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-6",
     max_tokens=1024,
     messages=[{"role": "user", "content": "Write a haiku"}]
 ) as stream:
@@ -92,7 +92,7 @@ const client = new Anthropic({
 });
 
 const stream = client.messages.stream({
-  model: 'claude-sonnet-4-20250514',
+  model: 'claude-sonnet-4-6',
   max_tokens: 1024,
   messages: [{ role: 'user', content: 'Write a haiku' }]
 });
@@ -122,9 +122,9 @@ PasteGuard adds headers to indicate PII and secrets handling:
 
 ## Content Types
 
-PasteGuard scans all text content in Anthropic requests:
+PasteGuard scans configured text roles in Anthropic requests. By default it scans:
 
 - **User messages** — String content or text blocks
-- **Assistant messages** — Including thinking blocks
-- **System prompts** — String or content block array
 - **Tool results** — Text content in tool responses
+
+Assistant messages and system prompts are available as scan roles, but are skipped by default. Add them to `pii_detection.scan_roles` or `secrets_detection.scan_roles` if you want PasteGuard to inspect them.

--- a/docs/api-reference/mask.mdx
+++ b/docs/api-reference/mask.mdx
@@ -86,7 +86,7 @@ curl -X POST http://localhost:3000/api/mask \
 curl -X POST http://localhost:3000/api/mask \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...",
+    "text": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----",
     "detect": ["secrets"]
   }'
 ```
@@ -95,7 +95,7 @@ curl -X POST http://localhost:3000/api/mask \
 curl -X POST http://localhost:3000/api/mask \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Contact john@example.com with key -----BEGIN RSA PRIVATE KEY-----..."
+    "text": "Contact john@example.com with key -----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----"
   }'
 ```
 

--- a/docs/api-reference/status.mdx
+++ b/docs/api-reference/status.mdx
@@ -66,7 +66,7 @@ curl http://localhost:3000/info
 ```json
 {
   "name": "PasteGuard",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "Privacy proxy for LLMs",
   "mode": "mask",
   "providers": {

--- a/docs/use-cases/apps.mdx
+++ b/docs/use-cases/apps.mdx
@@ -12,6 +12,7 @@ Point Open WebUI to PasteGuard instead of OpenAI directly:
 
 ```bash
 OPENAI_API_BASE_URL=http://localhost:3000/openai/v1
+OPENAI_API_KEY=your_openai_api_key
 ```
 
 <Note>In Docker Compose, use the service name instead of `localhost` (e.g., `http://pasteguard:3000/openai/v1`).</Note>
@@ -21,7 +22,7 @@ OPENAI_API_BASE_URL=http://localhost:3000/openai/v1
 Add PasteGuard as a custom endpoint in your LibreChat configuration:
 
 ```yaml
-version: 1.2.8
+version: 1.3.13
 cache: true
 endpoints:
   custom:


### PR DESCRIPTION
Updates the Anthropic API examples to use a tested model and align scan-role wording with current defaults. Completes the Mask API PEM examples and corrects the /info version example. Adds the missing Open WebUI API key environment variable and refreshes the LibreChat config example version. Verified with bun run check plus local PasteGuard smoke tests for Claude Code, Codex CLI, OpenAI-compatible app requests, Python OpenAI SDK, LangChain, and the browser-extension mask endpoint.