### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/docs/api-reference/status.mdx
+++ b/docs/api-reference/status.mdx
@@ -66,7 +66,7 @@ curl http://localhost:3000/info
 ```json
 {
   "name": "PasteGuard",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Privacy proxy for LLMs",
   "mode": "mask",
   "providers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## What
- Bump PasteGuard to 0.7.1
- Update the /info docs example version

## Verification
- bun run typecheck
- bun run typecheck:benchmarks
- bun run check
- bun test
- ruff check .
- ruff format . --check
- python3 -m pytest -q