### PR TITLE
Bump version to 0.7.2

### DIFF
--- a/docs/api-reference/status.mdx
+++ b/docs/api-reference/status.mdx
@@ -66,7 +66,7 @@ curl http://localhost:3000/info
 ```json
 {
   "name": "PasteGuard",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Privacy proxy for LLMs",
   "mode": "mask",
   "providers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bumps PasteGuard from 0.7.1 to 0.7.2 after the restored secrets marker fix.
- Updates the documented /info version example to match the package version.

## Verification
- `bun test`
- `bun run typecheck`
- `bun run check`