### PR TITLE
Refine PasteGuard positioning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
 </p>
 
 <p align="center">
-  <strong>AI gets the context. Not your secrets.</strong><br>
-  Automatically hides names, emails, and API keys before you send prompts to AI.
+  <strong>AI gets the context. Not your private data.</strong><br>
+  PasteGuard masks PII and secrets before they reach ChatGPT, Claude, Gemini, your API provider, Codex, or Claude Code.
 </p>
 
 <p align="center">
-  <a href="#quick-start"><strong>Quick Start</strong></a> ·
-  <a href="#chat"><strong>Chat</strong></a> ·
-  <a href="#coding-tools"><strong>Coding Tools</strong></a> ·
+  <a href="#browser-chat"><strong>Browser Chat</strong></a> ·
+  <a href="#apps--apis"><strong>Apps & APIs</strong></a> ·
+  <a href="#coding-agents"><strong>Coding Agents</strong></a> ·
   <a href="https://pasteguard.com/docs"><strong>Documentation</strong></a>
 </p>
 
@@ -29,23 +29,52 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/comparison-dark.png">
   <source media="(prefers-color-scheme: light)" srcset="assets/comparison.png">
-  <img src="assets/comparison.png" width="100%" alt="PasteGuard — Without vs. With: masks names, emails, and API keys before they reach AI">
+  <img src="assets/comparison.png" width="100%" alt="PasteGuard masks names, emails, and API keys before they reach AI">
 </picture>
 
 <p align="center">
-  Detects personal data and secrets in many languages.<br>
-  Your data never leaves your machine.
+  You keep the originals. Providers see placeholders.<br>
+  Run it locally or self-host it in your own infrastructure.
 </p>
 
-## Works Everywhere
+## What PasteGuard Protects
 
-**[Chat](https://pasteguard.com/docs/use-cases/chat)** — Masks PII and secrets when you paste into ChatGPT, Claude, and Gemini. You see originals, AI sees placeholders.
+PasteGuard is a local-first privacy layer for teams that cannot send raw client data, customer records, logs, credentials, or production details directly to model providers.
 
-**[Apps](https://pasteguard.com/docs/use-cases/apps)** — Open WebUI, LibreChat, or any self-hosted AI setup. Optionally routes sensitive requests to a local model.
+It works in three places:
 
-**[Coding Tools](https://pasteguard.com/docs/use-cases/coding-tools)** — Cursor, Claude Code, Copilot, Windsurf — your codebase context flows to the provider. PasteGuard masks secrets and PII before they leave.
+### Browser Chat
 
-**[API Integration](https://pasteguard.com/docs/use-cases/api-integration)** — Sits between your code and OpenAI-compatible or Anthropic APIs. Change one URL, your users' data stays protected.
+**ChatGPT, Claude, and Gemini.** Paste customer notes, contracts, support tickets, candidate details, or internal context without sending the raw private values to the chat provider. You see the originals; the AI sees placeholders.
+
+The browser extension is currently in beta.
+
+**[Install browser extension](https://pasteguard.com/browser-extension)** · **[Browser Chat docs](https://pasteguard.com/docs/use-cases/chat)**
+
+### Apps & APIs
+
+**Apps, SDKs, and internal AI products.** Point your application to PasteGuard instead of the provider directly.
+
+Change one base URL. PasteGuard masks the request, forwards it to the configured provider, and restores supported placeholders in the response.
+
+**[Apps & APIs docs](https://pasteguard.com/docs/use-cases/api-integration)**
+
+### Coding Agents
+
+**Codex, Claude Code, Cursor, Windsurf, Copilot, and other coding agents.** Agent prompts often include logs, stack traces, tickets, config files, test fixtures, and codebase context. PasteGuard masks secrets and PII before that context leaves your machine.
+
+**[Coding Agents docs](https://pasteguard.com/docs/use-cases/coding-tools)**
+
+## Built For Strict Privacy Rules
+
+PasteGuard is not a compliance certification and does not make your system compliant by itself. It is designed for teams that need a local or self-hosted control point before AI providers.
+
+Use it when your current options are:
+
+- Do not use cloud AI for sensitive work
+- Redact client or production data manually
+- Fall back to a weaker local model because the provider cannot see real context
+- Build one-off masking code inside every app
 
 ## Quick Start
 
@@ -57,7 +86,7 @@ docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:latest
 
 Open [localhost:3000](http://localhost:3000) for the dashboard.
 
-Point your tools or app to PasteGuard instead of the provider:
+Point your app or agent to PasteGuard instead of the provider:
 
 | Target | PasteGuard URL | Original URL |
 |----------|----------------|--------------|
@@ -66,48 +95,38 @@ Point your tools or app to PasteGuard instead of the provider:
 | Codex CLI | `http://localhost:3000/codex` | `https://chatgpt.com/backend-api/codex` |
 
 ```python
-# One line to protect your data
+from openai import OpenAI
+
 client = OpenAI(base_url="http://localhost:3000/openai/v1")
 ```
 
-Detection is multilingual out of the box — no per-language images or setup. For custom config or persistent logs: **[Read the docs →](https://pasteguard.com/docs/installation)**
+For custom config, persistent logs, Docker Compose, or detector settings: **[Read the docs](https://pasteguard.com/docs/installation)**.
+
+## Privacy Modes
+
+<details>
+<summary><strong>Mask Mode</strong></summary>
+
+Mask Mode replaces PII and secrets with placeholders before sending the request to the upstream AI provider. Supported responses are restored before they return to the user.
+
+</details>
 
 <details>
 <summary><strong>Route Mode</strong></summary>
 
-Route Mode sends requests containing sensitive data to a local LLM (Ollama, vLLM, llama.cpp). Everything else goes to the configured cloud provider. Sensitive data stays on your network.
+Route Mode sends requests containing sensitive data to a local LLM such as Ollama, vLLM, or llama.cpp. Requests without sensitive data can still go to the configured cloud provider.
 
-**[Route Mode docs →](https://pasteguard.com/docs/concepts/route-mode)**
+**[Route Mode docs](https://pasteguard.com/docs/concepts/route-mode)**
 
 </details>
 
-## Chat
+## What It Catches
 
-Open-source browser extension for ChatGPT, Claude, and Gemini.
+**Personal data**: Names, locations, emails, phone numbers, credit cards, IBANs, IP addresses, and EU VAT numbers. Detection is multilingual.
 
-- Paste customer data → masked before it reaches the AI
-- AI responds with placeholders → you see the originals
-- Works with the same detection engine as the proxy
+**Secrets**: API keys for providers such as OpenAI, Anthropic, Stripe, AWS, and GitHub; SSH and PEM private keys; JWT tokens; bearer tokens; passwords; and connection strings.
 
-Currently in beta. Apache 2.0.
-
-**[Join the Beta →](https://tally.so/r/J9pNLr)** · **[Chat docs →](https://pasteguard.com/docs/use-cases/chat)**
-
-## Coding Tools
-
-Protect your codebase context and secrets when using AI coding assistants.
-
-**Claude Code:**
-
-```bash
-ANTHROPIC_BASE_URL=http://localhost:3000/anthropic claude
-```
-
-**Cursor:** Settings → Models → Enable "Override OpenAI Base URL" → `http://localhost:3000/openai/v1`
-
-**Codex CLI:** Configure a custom provider with `base_url = "http://127.0.0.1:3000/codex"`. See the coding tools docs for the full snippet.
-
-**[Coding Tools docs →](https://pasteguard.com/docs/use-cases/coding-tools)**
+Both are detected and masked in real time, including streaming responses.
 
 ## Dashboard
 
@@ -117,17 +136,9 @@ Every request is logged with masking details. See what was detected, what was ma
 
 [localhost:3000](http://localhost:3000)
 
-## What it catches
+## How Detection Works
 
-**Personal data** — Names, locations, emails, phone numbers, credit cards, IBANs, IP addresses, and EU VAT numbers. Works in many languages.
-
-**Secrets** — API keys (OpenAI, Anthropic, Stripe, AWS, GitHub), SSH and PEM private keys, JWT tokens, bearer tokens, passwords, connection strings.
-
-Both detected and masked in real time, including streaming responses.
-
-## How detection works
-
-Detection runs as a separate service that PasteGuard calls over HTTP, so you can run it wherever you like. It mixes exact checks with checksums (IBANs, credit cards, emails, phones, IPs) and a small AI model ([GLiNER](https://github.com/urchade/GLiNER)) for names and places. It works the same in any language. Phone numbers are international-only by default; add `phone_regions` if you need local formats.
+Detection runs as a separate service that PasteGuard calls over HTTP, so you can run it wherever you like. It combines deterministic checks and checksums for structured values with a small AI model ([GLiNER](https://github.com/urchade/GLiNER)) for names and places.
 
 Code, Docker image, and tests are in [`detector/`](detector/).
 

--- a/docs/concepts/local-first-privacy.mdx
+++ b/docs/concepts/local-first-privacy.mdx
@@ -1,0 +1,72 @@
+---
+title: Local-First Privacy
+description: What stays local, what reaches AI providers, and how PasteGuard restores placeholders
+---
+
+PasteGuard is designed to put a privacy layer before AI providers. The goal is simple: useful context can still reach the model, but sensitive values are replaced before the request leaves your environment.
+
+## What Stays Local
+
+In a local or self-hosted deployment, PasteGuard keeps the sensitive originals inside your environment.
+
+Examples:
+
+- Names
+- Email addresses
+- Phone numbers
+- Account identifiers
+- API keys
+- Bearer tokens
+- Private keys
+- Connection strings
+
+PasteGuard stores a temporary placeholder mapping so supported responses can be restored before they return to the user.
+
+## What Providers See
+
+Providers receive masked prompts such as:
+
+```text
+Write a follow-up to [[PERSON_1]] at [[EMAIL_ADDRESS_1]] about the renewal.
+```
+
+The model still gets useful structure and context, but not the original private value.
+
+## Restoration
+
+In mask mode, PasteGuard restores supported placeholders in the model response before returning it to the user.
+
+For example:
+
+```text
+Provider response: I can draft a note to [[PERSON_1]].
+User receives: I can draft a note to Dr. Sarah Chen.
+```
+
+Restoration depends on the provider endpoint and response format. OpenAI Chat Completions, Anthropic Messages, and Codex Responses have provider-specific extraction and restoration paths.
+
+## Browser Extension
+
+The browser extension is currently in beta. It uses a local PasteGuard server for masking and restoration so browser chat can follow the same privacy model as the proxy.
+
+## Logs And Dashboard
+
+PasteGuard includes a local dashboard that shows request history, detected entities, and masked content sent upstream when logging is enabled.
+
+Review [Logging](/configuration/logging) before using PasteGuard with production or regulated data. Configure retention and masked-content logging according to your organization's policy.
+
+## Route Mode
+
+Route mode is stricter than mask mode. Requests containing sensitive data can be sent to a local model instead of a cloud provider.
+
+Use route mode when a use case should not send even masked sensitive requests to a cloud model.
+
+<Card title="Route Mode" icon="route" href="/concepts/route-mode">
+  Configure local routing for sensitive requests
+</Card>
+
+## What PasteGuard Does Not Claim
+
+PasteGuard does not by itself certify compliance with DORA, GDPR, HIPAA, SOC 2, or any other framework.
+
+It gives teams a local or self-hosted control point before requests reach model providers.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,42 +1,52 @@
 ---
 title: Introduction
-description: AI gets the context. Not your secrets. Open-source privacy proxy for OpenAI, Anthropic, and any AI.
+description: AI gets the context. Not your private data. PasteGuard protects Browser Chat, Apps & APIs, and Coding Agents.
 ---
 
-PasteGuard automatically hides names, emails, and API keys before you send prompts to AI. Your data never leaves your machine.
+PasteGuard masks PII and secrets before they reach ChatGPT, Claude, Gemini, your API provider, Codex, or Claude Code. You keep the originals. Providers see placeholders.
 
-Detects personal data and secrets in many languages.
+It is built for teams that want to use AI with real context but cannot send raw client, customer, production, or credential data to model providers.
 
 <Frame>
-  <img className="block dark:hidden" src="/images/comparison-light.png" alt="PasteGuard Comparison" />
-  <img className="hidden dark:block" src="/images/comparison-dark.png" alt="PasteGuard Comparison" />
+  <img className="block dark:hidden" src="/images/comparison-light.png" alt="PasteGuard masks names, emails, and API keys before they reach AI" />
+  <img className="hidden dark:block" src="/images/comparison-dark.png" alt="PasteGuard masks names, emails, and API keys before they reach AI" />
 </Frame>
 
-## Works Everywhere
+## One Privacy Layer
 
-<CardGroup cols={2}>
-  <Card title="Chat" icon="comment" href="/use-cases/chat">
-    ChatGPT, Claude, Gemini
+<CardGroup cols={3}>
+  <Card title="Browser Chat" icon="comment" href="/use-cases/chat">
+    ChatGPT, Claude, and Gemini. Browser extension beta.
   </Card>
-  <Card title="Apps" icon="table-columns" href="/use-cases/apps">
-    Open WebUI, LibreChat
+  <Card title="Apps & APIs" icon="plug" href="/use-cases/api-integration">
+    Apps, SDKs, and internal AI products.
   </Card>
-  <Card title="Coding Tools" icon="code" href="/use-cases/coding-tools">
-    Cursor, Claude Code, Copilot, Windsurf
-  </Card>
-  <Card title="API Integration" icon="plug" href="/use-cases/api-integration">
-    OpenAI SDK, Anthropic SDK, LangChain
+  <Card title="Coding Agents" icon="code" href="/use-cases/coding-tools">
+    Codex, Claude Code, Cursor, Windsurf, and other coding agents.
   </Card>
 </CardGroup>
 
-## Two Privacy Modes
+## Built For Raw Data Limits
+
+PasteGuard does not certify your organization as compliant. It gives teams a local or self-hosted control point before requests reach AI providers.
+
+Use it when the current options are manual redaction, no cloud AI for sensitive work, a weaker local-only model, or custom masking code in every app.
+
+<CardGroup cols={2}>
+  <Card title="Regulated Teams" icon="shield-check" href="/use-cases/regulated-teams">
+    Patterns for finance, legal, healthcare, consulting, and other sensitive work.
+  </Card>
+  <Card title="Local-First Privacy" icon="lock" href="/concepts/local-first-privacy">
+    What stays local, what reaches providers, and how placeholders are restored.
+  </Card>
+</CardGroup>
+
+## Privacy Modes
 
 | Mode | How it works |
 |------|--------------|
-| **Mask** | Replace PII with placeholders, send to the upstream AI service, restore in response |
-| **Route** | PII requests stay on your local LLM (Ollama, vLLM, llama.cpp), others go to the configured cloud provider |
-
-PasteGuard runs on your servers. Personal data never leaves your infrastructure, and the LLM provider never sees real names, emails, or secrets.
+| **Mask** | Replace PII and secrets with placeholders, send to the upstream AI service, restore supported placeholders in the response |
+| **Route** | Requests with sensitive data stay on your local LLM; other requests go to the configured cloud provider |
 
 ## Next Steps
 
@@ -44,7 +54,7 @@ PasteGuard runs on your servers. Personal data never leaves your infrastructure,
   <Card title="Quickstart" icon="rocket" href="/quickstart">
     Run PasteGuard as a local proxy
   </Card>
-  <Card title="Configuration" icon="gear" href="/configuration/overview">
-    Customize detection and providers
+  <Card title="Installation" icon="box" href="/installation">
+    Configure Docker, persistent logs, and detector settings
   </Card>
 </CardGroup>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -40,14 +40,15 @@
       "group": "Use Cases",
       "pages": [
         "use-cases/chat",
-        "use-cases/apps",
+        "use-cases/api-integration",
         "use-cases/coding-tools",
-        "use-cases/api-integration"
+        "use-cases/regulated-teams"
       ]
     },
     {
       "group": "Concepts",
       "pages": [
+        "concepts/local-first-privacy",
         "concepts/mask-mode",
         "concepts/route-mode",
         "concepts/pii-detection",

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Run PasteGuard as a local proxy
+description: Run PasteGuard locally and connect Browser Chat, Apps & APIs, or Coding Agents
 ---
 
 ## 1. Start PasteGuard
@@ -12,12 +12,26 @@ docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:latest
 PasteGuard runs on `http://localhost:3000`. Open `http://localhost:3000` to see the dashboard.
 
 <Note>
-For custom configuration or persistent logs, see [Installation](/installation).
+For custom configuration, Docker Compose, or persistent logs, see [Installation](/installation).
 </Note>
 
-## 2. API Endpoints
+## 2. Choose Your Path
 
-Point your tools or SDKs to PasteGuard:
+<CardGroup cols={3}>
+  <Card title="Browser Chat" icon="comment" href="/use-cases/chat">
+    Use the browser extension beta with ChatGPT, Claude, and Gemini.
+  </Card>
+  <Card title="Apps & APIs" icon="plug" href="/use-cases/api-integration">
+    Change one base URL for your app or SDK.
+  </Card>
+  <Card title="Coding Agents" icon="code" href="/use-cases/coding-tools">
+    Point Codex, Claude Code, Cursor, and other coding agents at PasteGuard.
+  </Card>
+</CardGroup>
+
+## 3. API Endpoints
+
+Point your app, SDK, or coding agent to PasteGuard:
 
 | Target | PasteGuard URL |
 |----------|----------------|
@@ -25,7 +39,7 @@ Point your tools or SDKs to PasteGuard:
 | Anthropic | `http://localhost:3000/anthropic` |
 | Codex CLI | `http://localhost:3000/codex` |
 
-## 3. Verify It Works
+## 4. Verify It Works
 
 Send a test request and check the response headers:
 
@@ -37,38 +51,22 @@ curl -i http://localhost:3000/openai/v1/chat/completions \
 ```
 
 Look for:
-```
+
+```text
 X-PasteGuard-PII-Detected: true
 X-PasteGuard-PII-Masked: true
 ```
 
 The name and email were masked before reaching OpenAI and restored in the response.
 
-## 4. View Dashboard
+## 5. View Dashboard
 
 Open `http://localhost:3000` in your browser to see:
 
 - Request history
-- Detected PII entities
+- Detected PII and secrets
 - Masked content sent to upstream APIs or Codex CLI
 
 <Frame>
   <img src="/images/dashboard.png" alt="PasteGuard Dashboard" />
 </Frame>
-
-## Now Configure Your Tool
-
-<CardGroup cols={2}>
-  <Card title="Chat" icon="comment" href="/use-cases/chat">
-    ChatGPT, Claude, Gemini
-  </Card>
-  <Card title="Apps" icon="table-columns" href="/use-cases/apps">
-    Open WebUI, LibreChat
-  </Card>
-  <Card title="Coding Tools" icon="code" href="/use-cases/coding-tools">
-    Cursor, Claude Code, Copilot, Windsurf
-  </Card>
-  <Card title="API Integration" icon="plug" href="/use-cases/api-integration">
-    OpenAI SDK, Anthropic SDK, LangChain
-  </Card>
-</CardGroup>

--- a/docs/use-cases/api-integration.mdx
+++ b/docs/use-cases/api-integration.mdx
@@ -1,10 +1,12 @@
 ---
-title: API Integration
-sidebarTitle: API Integration
-description: Mask PII in your AI-powered application with OpenAI, Anthropic, LangChain, and LlamaIndex
+title: Apps & APIs
+sidebarTitle: Apps & APIs
+description: Add PII and secrets protection to apps and SDKs that call AI providers
 ---
 
-Point your SDK to PasteGuard instead of the provider directly. Every request gets PII and secrets protection automatically.
+Use this path for apps, SDKs, internal AI products, customer-facing AI features, and automation that calls model providers through HTTP APIs.
+
+Point the app to PasteGuard instead of the provider directly. PasteGuard masks PII and secrets, forwards the request, and restores supported placeholders in the response.
 
 ## OpenAI SDK
 
@@ -50,6 +52,14 @@ const client = new Anthropic({
 
 </CodeGroup>
 
+## Self-Hosted App Examples
+
+Self-hosted products such as Open WebUI and LibreChat can also use PasteGuard as their OpenAI-compatible endpoint.
+
+<Card title="Open WebUI and LibreChat" icon="table-columns" href="/use-cases/apps">
+  Example configuration for self-hosted chat products
+</Card>
+
 ## LangChain
 
 ```python
@@ -71,3 +81,12 @@ llm = OpenAILike(
     is_chat_model=True
 )
 ```
+
+## When To Use This Path
+
+Use this path when you are building or operating the app:
+
+- Internal support, legal, finance, or operations apps
+- Customer-facing AI features that may process user data
+- Self-hosted AI interfaces for teams
+- Regulated teams that need a local or self-hosted control point before requests reach a provider

--- a/docs/use-cases/apps.mdx
+++ b/docs/use-cases/apps.mdx
@@ -1,10 +1,10 @@
 ---
-title: Apps
-sidebarTitle: Apps
-description: Protect data in Open WebUI, LibreChat, and other self-hosted AI setups
+title: Open WebUI and LibreChat
+sidebarTitle: Open WebUI and LibreChat
+description: Example configuration for self-hosted chat products inside Apps & APIs
 ---
 
-PasteGuard sits between your self-hosted chat interface and the LLM provider. Users interact with Open WebUI, LibreChat, or similar tools — PasteGuard handles privacy automatically in the background.
+Open WebUI and LibreChat are examples inside the Apps & APIs path. Users keep the same chat UI while PasteGuard handles masking, forwarding, restoration, and dashboard logging in the background.
 
 ## Open WebUI
 
@@ -15,7 +15,7 @@ OPENAI_API_BASE_URL=http://localhost:3000/openai/v1
 OPENAI_API_KEY=your_openai_api_key
 ```
 
-<Note>In Docker Compose, use the service name instead of `localhost` (e.g., `http://pasteguard:3000/openai/v1`).</Note>
+<Note>In Docker Compose, use the service name instead of `localhost`, such as `http://pasteguard:3000/openai/v1`.</Note>
 
 ## LibreChat
 
@@ -27,7 +27,7 @@ cache: true
 endpoints:
   custom:
     - name: "PasteGuard"
-      apiKey: "${OPENAI_API_KEY}"  # Your API key, forwarded to OpenAI
+      apiKey: "${OPENAI_API_KEY}"
       baseURL: "http://localhost:3000/openai/v1"
       models:
         default: ["gpt-5.2"]
@@ -42,8 +42,8 @@ Self-hosted setups can use either privacy mode depending on your requirements:
 
 | Mode | Best for | How it works |
 |------|----------|--------------|
-| **Mask** | Teams using cloud LLMs (OpenAI, Anthropic) | Replaces PII with placeholders, sends to cloud provider, restores in response |
-| **Route** | Teams with a local LLM (Ollama, vLLM) | Requests containing PII stay on your local LLM, others go to the cloud provider |
+| **Mask** | Teams using cloud LLMs | Replaces PII and secrets with placeholders, sends to the cloud provider, restores supported placeholders in the response |
+| **Route** | Teams with a local LLM | Requests containing sensitive data stay on your local LLM, others go to the cloud provider |
 
 Route Mode requires a local LLM provider configured in `config.yaml`. See [Route Mode](/concepts/route-mode) for setup details.
 

--- a/docs/use-cases/chat.mdx
+++ b/docs/use-cases/chat.mdx
@@ -1,25 +1,41 @@
 ---
-title: Chat
-sidebarTitle: Chat
-description: Mask PII when pasting into ChatGPT, Claude, and Gemini
+title: Browser Chat
+sidebarTitle: Browser Chat
+description: Mask private data before it reaches ChatGPT, Claude, or Gemini
 ---
 
-Paste customer data into ChatGPT — the AI sees `[[PERSON_1]]` and `[[EMAIL_ADDRESS_1]]`. When you copy the response, placeholders are replaced with the originals.
+Browser Chat protects what people already do: paste real context into ChatGPT, Claude, and Gemini.
+
+PasteGuard masks names, emails, account details, customer notes, contracts, support tickets, and other sensitive values before they reach the chat provider. You keep the originals. The AI sees placeholders.
+
+<Note>
+The browser extension is currently in beta.
+</Note>
 
 ## Supported Platforms
 
-- ChatGPT (chatgpt.com)
-- Claude (claude.ai)
-- Google Gemini (gemini.google.com)
+- ChatGPT (`chatgpt.com`)
+- Claude (`claude.ai`)
+- Google Gemini (`gemini.google.com`)
 
 ## How It Works
 
-1. **Paste** — You paste text containing PII into the chat input
-2. **Mask** — The extension detects and masks PII via your local PasteGuard server
-3. **Chat** — The masked text is inserted into the chat. The AI only sees placeholders.
-4. **Copy** — When you copy the AI's response, placeholders are replaced with the original values
+1. **Paste**: You paste text containing PII or secrets into the chat input.
+2. **Mask**: The extension sends text to your local PasteGuard server for masking.
+3. **Chat**: Masked text is inserted into the chat. The provider sees placeholders such as `[[PERSON_1]]` and `[[EMAIL_ADDRESS_1]]`.
+4. **Copy**: When you copy a supported AI response, placeholders are replaced with the original values.
 
-Placeholder numbering stays consistent across messages in the same conversation. Streamed responses are highlighted in real-time.
+Placeholder numbering stays consistent across messages in the same conversation. Streamed responses are highlighted in real time.
+
+## Who This Helps
+
+Browser Chat is useful for teams that want AI help with real work but cannot paste raw sensitive data into third-party chat products:
+
+- Advisors and consultants working with client data
+- Legal teams handling contracts or privileged context
+- Support and success teams working with customer tickets
+- Recruiting and HR teams handling candidate or employee data
+- Finance, insurance, and healthcare-adjacent work with strict confidentiality needs
 
 ## Requirements
 
@@ -31,10 +47,10 @@ docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:latest
 
 See [Quickstart](/quickstart) for setup details.
 
-## Beta
+## Install Browser Extension
 
-The browser extension is in beta. Open source (Apache 2.0).
+The browser extension uses the same detection and masking engine as the local proxy.
 
-<Card title="Join the Beta" icon="flask" href="https://tally.so/r/J9pNLr">
-  Get early access to the browser extension
+<Card title="Install browser extension" icon="flask" href="https://pasteguard.com/browser-extension">
+  Add PasteGuard to Firefox or Chrome
 </Card>

--- a/docs/use-cases/coding-tools.mdx
+++ b/docs/use-cases/coding-tools.mdx
@@ -1,34 +1,23 @@
 ---
-title: Coding Tools
-description: Protect your codebase context and secrets in Claude Code, Cursor, and other AI coding assistants
+title: Coding Agents
+sidebarTitle: Coding Agents
+description: Protect codebase context, logs, tickets, and secrets in Codex, Claude Code, and other coding agents
 ---
 
-PasteGuard protects your codebase when you use AI coding assistants. Config files with database credentials, customer data in test fixtures, API keys in environment files — all masked before reaching the provider.
+Coding agents often receive more than code. They see logs, stack traces, support tickets, config snippets, test fixtures, environment examples, and production context.
+
+PasteGuard sits between the coding agent and the provider, masks PII and secrets before the request leaves your environment, and restores supported placeholders in responses.
 
 ## What Gets Detected
 
-- **Secrets** — API keys, private keys, database passwords, tokens in config files and `.env` files
-- **PII** — Customer names, emails, phone numbers in code comments, test data, or log output
+- **Secrets**: API keys, private keys, database passwords, bearer tokens, JWTs, connection strings, and `.env` values
+- **PII**: Customer names, emails, phone numbers, locations, account data, test fixtures, comments, and log output
 
-PII detection works [in many languages](/installation). Full entity lists: [PII Detection](/concepts/pii-detection), [Secrets Detection](/concepts/secrets-detection).
-
-## Claude Code
-
-One environment variable:
-
-```bash
-ANTHROPIC_BASE_URL=http://localhost:3000/anthropic claude
-```
-
-To make it permanent, add to your shell profile:
-
-```bash
-export ANTHROPIC_BASE_URL=http://localhost:3000/anthropic
-```
+PII detection works [in many languages](/concepts/pii-detection). Full entity lists: [PII Detection](/concepts/pii-detection), [Secrets Detection](/concepts/secrets-detection).
 
 ## Codex CLI
 
-Codex users signed in with ChatGPT should use PasteGuard's Codex endpoint, not the OpenAI API endpoint:
+Codex users signed in with ChatGPT should use PasteGuard's Codex endpoint:
 
 ```toml
 model_provider = "pasteguard-codex"
@@ -51,23 +40,37 @@ codex exec --skip-git-repo-check 'Reply with exactly: ok'
 Codex Responses requests are scanned, masked, unmasked, and shown in the dashboard. In route mode, sensitive Codex requests are blocked because PasteGuard does not route Codex Responses traffic to a local provider.
 </Note>
 
+## Claude Code
+
+One environment variable:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:3000/anthropic claude
+```
+
+To make it permanent, add to your shell profile:
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:3000/anthropic
+```
+
 ## Cursor
 
-1. Open **Settings** → **Models**
-2. Scroll to **API Keys** section
-3. Enable **Override OpenAI Base URL** toggle
+1. Open **Settings** -> **Models**
+2. Scroll to **API Keys**
+3. Enable **Override OpenAI Base URL**
 4. Enter: `http://localhost:3000/openai/v1`
 5. Add your OpenAI API key
 
-## Environment Variables
+## Other Coding Agents
 
-Most AI coding tools respect the standard environment variables:
+Most coding agents respect standard provider base URL settings:
 
 ```bash
-# OpenAI-compatible tools
+# OpenAI-compatible agents
 export OPENAI_API_BASE=http://localhost:3000/openai/v1
 
-# Anthropic tools (Claude Code, etc.)
+# Anthropic-compatible agents
 export ANTHROPIC_BASE_URL=http://localhost:3000/anthropic
 ```
 
@@ -75,6 +78,6 @@ export ANTHROPIC_BASE_URL=http://localhost:3000/anthropic
 
 | Target | PasteGuard URL |
 |----------|----------------|
-| OpenAI | `http://localhost:3000/openai/v1` |
-| Anthropic | `http://localhost:3000/anthropic` |
+| OpenAI-compatible agents | `http://localhost:3000/openai/v1` |
+| Anthropic-compatible agents | `http://localhost:3000/anthropic` |
 | Codex CLI | `http://localhost:3000/codex` |

--- a/docs/use-cases/regulated-teams.mdx
+++ b/docs/use-cases/regulated-teams.mdx
@@ -1,0 +1,72 @@
+---
+title: Regulated Teams
+sidebarTitle: Regulated Teams
+description: Use AI with sensitive context without sending raw private values to model providers
+---
+
+Regulated teams often want AI help, but the useful context is exactly the context they cannot paste into a third-party provider unchanged.
+
+PasteGuard gives these teams a local or self-hosted privacy layer before requests leave their environment.
+
+## Common Status Quo
+
+Teams usually choose one of these options before adopting a privacy layer:
+
+- Avoid cloud AI for sensitive work
+- Redact client or production data manually
+- Use a weaker local model because cloud providers cannot receive raw data
+- Build one-off masking code inside each app
+
+PasteGuard is designed to replace that manual step with a consistent control point.
+
+## Who It Fits
+
+PasteGuard is useful when sensitive values appear in normal AI work:
+
+- Finance and banking work with customer or transaction context
+- Legal and advisory work with privileged or client-confidential material
+- Healthcare-adjacent operations with patient or provider details
+- Insurance, accounting, consulting, HR, and recruiting work
+- Regulated SaaS teams handling logs, support tickets, and production context
+
+## Product Paths
+
+<CardGroup cols={3}>
+  <Card title="Browser Chat" icon="comment" href="/use-cases/chat">
+    Browser extension beta for ChatGPT, Claude, and Gemini.
+  </Card>
+  <Card title="Apps & APIs" icon="plug" href="/use-cases/api-integration">
+    Apps, SDKs, internal AI products, and provider-compatible APIs.
+  </Card>
+  <Card title="Coding Agents" icon="code" href="/use-cases/coding-tools">
+    Codex, Claude Code, logs, tickets, codebase context, and secrets.
+  </Card>
+</CardGroup>
+
+## Deployment Model
+
+PasteGuard can run locally for individual use, or self-hosted for team and infrastructure use.
+
+Use local or self-hosted deployment when your team needs tighter control over:
+
+- Where private values are processed
+- Which provider receives masked requests
+- What request metadata is logged
+- How sensitive requests are routed to local models
+- How masking rules are configured
+
+<Warning>
+PasteGuard is not a compliance certification and does not make an organization compliant by itself. It can help keep sensitive values out of prompts before they reach a provider.
+</Warning>
+
+## What To Validate In A Pilot
+
+For a regulated pilot, validate the trust questions before adding more features:
+
+- Can users complete real work without manual redaction?
+- Do they understand which values stayed local?
+- Do they trust the restoration flow?
+- Do they need local, self-hosted, or managed deployment?
+- Which logs and audit exports are required before production use?
+
+Start with [Local-First Privacy](/concepts/local-first-privacy), then connect the path your team uses most: [Browser Chat](/use-cases/chat), [Apps & APIs](/use-cases/api-integration), or [Coding Agents](/use-cases/coding-tools).


### PR DESCRIPTION
Updates the README and docs around three clear product paths: Browser Chat, Apps & APIs, and Coding Agents.
Adds Local-First Privacy and Regulated Teams pages, and moves Open WebUI/LibreChat into Apps & APIs examples instead of a separate top-level path.
Refreshes quickstart, use case pages, and docs navigation to match the new positioning.
Validated with `bun run check`, `bun run typecheck`, `bun test`, and website copy/build checks.
