### PR TITLE
Soften compliance boundary wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Change one base URL. PasteGuard masks the request, forwards it to the configured
 
 ## Built For Strict Privacy Rules
 
-PasteGuard is not a compliance certification and does not make your system compliant by itself. It is designed for teams that need a local or self-hosted control point before AI providers.
+PasteGuard is a privacy control point before AI providers. It can support regulated workflows, but it does not replace your legal, security, or compliance program.
 
 Use it when your current options are:
 

--- a/docs/concepts/local-first-privacy.mdx
+++ b/docs/concepts/local-first-privacy.mdx
@@ -65,7 +65,7 @@ Use route mode when a use case should not send even masked sensitive requests to
   Configure local routing for sensitive requests
 </Card>
 
-## What PasteGuard Does Not Claim
+## Compliance Boundary
 
 PasteGuard does not by itself certify compliance with DORA, GDPR, HIPAA, SOC 2, or any other framework.
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -28,7 +28,7 @@ It is built for teams that want to use AI with real context but cannot send raw 
 
 ## Built For Raw Data Limits
 
-PasteGuard does not certify your organization as compliant. It gives teams a local or self-hosted control point before requests reach AI providers.
+PasteGuard gives teams a local or self-hosted control point before requests reach AI providers.
 
 Use it when the current options are manual redaction, no cloud AI for sensitive work, a weaker local-only model, or custom masking code in every app.
 

--- a/docs/use-cases/regulated-teams.mdx
+++ b/docs/use-cases/regulated-teams.mdx
@@ -56,7 +56,7 @@ Use local or self-hosted deployment when your team needs tighter control over:
 - How masking rules are configured
 
 <Warning>
-PasteGuard is not a compliance certification and does not make an organization compliant by itself. It can help keep sensitive values out of prompts before they reach a provider.
+PasteGuard can help keep sensitive values out of prompts before they reach a provider. Your legal, security, and compliance controls still decide whether a workflow is production-ready.
 </Warning>
 
 ## What To Validate In A Pilot


### PR DESCRIPTION
Softens repeated compliance disclaimer language in README and docs.
Keeps the detailed boundary on Local-First Privacy, removes the early docs-introduction disclaimer, and reframes regulated-team guidance around production readiness.
Validated with `bun run check`, `bun run typecheck`, and `bun test`.
