### PR TITLE
Update browser extension install copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ It works in three places:
 
 **ChatGPT, Claude, and Gemini.** Paste customer notes, contracts, support tickets, candidate details, or internal context without sending the raw private values to the chat provider. You see the originals; the AI sees placeholders.
 
-The browser extension beta is available for ChatGPT, Claude, and Gemini.
+The experimental browser extension is available for ChatGPT, Claude, and Gemini.
 
-**[Install browser extension](https://pasteguard.com/browser-extension)** · **[Browser Chat docs](https://pasteguard.com/docs/use-cases/chat)**
+**[Install the extension →](https://pasteguard.com/browser-extension)** · **[Chat docs →](https://pasteguard.com/docs/use-cases/chat)**
 
 ### Apps & APIs
 

--- a/docs/concepts/local-first-privacy.mdx
+++ b/docs/concepts/local-first-privacy.mdx
@@ -47,7 +47,7 @@ Restoration depends on the provider endpoint and response format. OpenAI Chat Co
 
 ## Browser Extension
 
-The browser extension beta uses a local PasteGuard server for masking and restoration so browser chat can follow the same privacy model as the proxy.
+The experimental browser extension uses a local PasteGuard server for masking and restoration so browser chat can follow the same privacy model as the proxy.
 
 ## Logs And Dashboard
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -16,7 +16,7 @@ It is built for teams that want to use AI with real context but cannot send raw 
 
 <CardGroup cols={3}>
   <Card title="Browser Chat" icon="comment" href="/use-cases/chat">
-    ChatGPT, Claude, and Gemini. Browser extension beta.
+    ChatGPT, Claude, and Gemini. Experimental browser extension.
   </Card>
   <Card title="Apps & APIs" icon="plug" href="/use-cases/api-integration">
     Apps, SDKs, and internal AI products.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -19,7 +19,7 @@ For custom configuration, Docker Compose, or persistent logs, see [Installation]
 
 <CardGroup cols={3}>
   <Card title="Browser Chat" icon="comment" href="/use-cases/chat">
-    Use the browser extension beta with ChatGPT, Claude, and Gemini.
+    Use the experimental browser extension with ChatGPT, Claude, and Gemini.
   </Card>
   <Card title="Apps & APIs" icon="plug" href="/use-cases/api-integration">
     Change one base URL for your app or SDK.

--- a/docs/use-cases/chat.mdx
+++ b/docs/use-cases/chat.mdx
@@ -9,7 +9,7 @@ Browser Chat protects what people already do: paste real context into ChatGPT, C
 PasteGuard masks names, emails, account details, customer notes, contracts, support tickets, and other sensitive values before they reach the chat provider. You keep the originals. The AI sees placeholders.
 
 <Note>
-The browser extension beta is available for ChatGPT, Claude, and Gemini.
+The browser extension is experimental and available for ChatGPT, Claude, and Gemini.
 </Note>
 
 ## Supported Platforms
@@ -21,9 +21,9 @@ The browser extension beta is available for ChatGPT, Claude, and Gemini.
 ## How It Works
 
 1. **Paste**: You paste text containing PII or secrets into the chat input.
-2. **Mask**: The extension sends text to your local PasteGuard server for masking.
-3. **Chat**: Masked text is inserted into the chat. The provider sees placeholders such as `[[PERSON_1]]` and `[[EMAIL_ADDRESS_1]]`.
-4. **Copy**: When you copy a supported AI response, placeholders are replaced with the original values.
+2. **Mask**: The extension sends text to your local PasteGuard server's `/api/mask` endpoint.
+3. **Chat**: PasteGuard masks secrets first, then PII, and returns masked text with local placeholder context. The provider sees placeholders such as `[[PERSON_1]]` and `[[EMAIL_ADDRESS_1]]`.
+4. **Copy**: When you copy a supported AI response, placeholders are replaced with the original values using the local context.
 
 Placeholder numbering stays consistent across messages in the same conversation. Streamed responses are highlighted in real time.
 
@@ -47,10 +47,10 @@ docker run --rm -p 3000:3000 ghcr.io/sgasser/pasteguard:latest
 
 See [Quickstart](/quickstart) for setup details.
 
-## Install Browser Extension
+## Browser extension
 
-The browser extension uses the same detection and masking engine as the local proxy.
+The browser extension is experimental and available for Chrome or Firefox. The PasteGuard server is open source (Apache 2.0); the extension source is planned to be published on GitHub after the beta stabilizes.
 
-<Card title="Install browser extension" icon="flask" href="https://pasteguard.com/browser-extension">
-  Add PasteGuard to Firefox or Chrome
+<Card title="Install the extension" icon="download" href="https://pasteguard.com/browser-extension">
+  Add PasteGuard to Chrome or Firefox
 </Card>

--- a/docs/use-cases/regulated-teams.mdx
+++ b/docs/use-cases/regulated-teams.mdx
@@ -33,7 +33,7 @@ PasteGuard is useful when sensitive values appear in normal AI work:
 
 <CardGroup cols={3}>
   <Card title="Browser Chat" icon="comment" href="/use-cases/chat">
-    Browser extension beta for ChatGPT, Claude, and Gemini.
+    Experimental browser extension for ChatGPT, Claude, and Gemini.
   </Card>
   <Card title="Apps & APIs" icon="plug" href="/use-cases/api-integration">
     Apps, SDKs, internal AI products, and provider-compatible APIs.


### PR DESCRIPTION
Updates README and docs to point browser extension CTAs to the install page and describe the extension as experimental.

Clarifies the Browser Chat flow through the local `/api/mask` endpoint and notes that extension source publication is planned after beta stabilization.

Validation: `bun test`; `bun run typecheck`; `bun run check`.