### PR TITLE
Avoid detector timeouts on long chats

### DIFF
--- a/src/pii/detect.test.ts
+++ b/src/pii/detect.test.ts
@@ -149,6 +149,44 @@ describe("PIIDetector", () => {
       expect(analyzeRequests).toEqual([expect.objectContaining({ text: "mcp-pii here" })]);
     });
 
+    test("scans spans sequentially to avoid detector-side inference queue timeouts", async () => {
+      const analyzeRequests: string[] = [];
+      let inFlight = 0;
+      let maxInFlight = 0;
+
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = url.toString();
+
+        if (urlStr.includes("/analyze") && init?.body) {
+          const body = JSON.parse(init.body as string);
+          analyzeRequests.push(body.text);
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          inFlight--;
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return originalFetch(url, init);
+      }) as unknown as typeof fetch;
+
+      const detector = new PIIDetector();
+      const spans: TextSpan[] = [
+        { text: "first", path: "0", messageIndex: 0, partIndex: 0, role: "user" },
+        { text: "second", path: "1", messageIndex: 1, partIndex: 0, role: "user" },
+        { text: "third", path: "2", messageIndex: 2, partIndex: 0, role: "user" },
+      ];
+
+      const result = await detector.analyzeRequest(spans, spanExtractor);
+
+      expect(result.hasPII).toBe(false);
+      expect(analyzeRequests).toEqual(["first", "second", "third"]);
+      expect(maxInFlight).toBe(1);
+    });
+
     test("honors explicit scan_roles override", async () => {
       const config = getConfig();
       const previousScanRoles = config.pii_detection.scan_roles;

--- a/src/pii/detect.ts
+++ b/src/pii/detect.ts
@@ -225,22 +225,23 @@ export class PIIDetector {
     const allowlist = config.masking.allowlist;
     const denylist = config.masking.denylist;
 
-    const spanEntities: PIIEntity[][] = await Promise.all(
-      spans.map(async (span) => {
-        if (!span.text) return [];
+    const spanEntities: PIIEntity[][] = [];
+    for (const span of spans) {
+      if (!span.text) {
+        spanEntities.push([]);
+        continue;
+      }
 
-        if (!span.role || !scanRoles.has(span.role)) {
-          return [];
-        }
+      if (!span.role || !scanRoles.has(span.role)) {
+        spanEntities.push([]);
+        continue;
+      }
 
-        const denylistedEntities = findDenylistedEntities(span.text, denylist, knownPlaceholders);
-        const detectedEntities = config.pii_detection.enabled
-          ? await this.detectPII(span.text)
-          : [];
-        const filteredEntities = filterAllowlistedEntities(span.text, detectedEntities, allowlist);
-        return mergeDenylistEntities(filteredEntities, denylistedEntities);
-      }),
-    );
+      const denylistedEntities = findDenylistedEntities(span.text, denylist, knownPlaceholders);
+      const detectedEntities = config.pii_detection.enabled ? await this.detectPII(span.text) : [];
+      const filteredEntities = filterAllowlistedEntities(span.text, detectedEntities, allowlist);
+      spanEntities.push(mergeDenylistEntities(filteredEntities, denylistedEntities));
+    }
 
     const allEntities = spanEntities.flat();
 


### PR DESCRIPTION
## What changed

- Scan extracted PII text spans sequentially instead of dispatching all detector requests concurrently.
- Add regression coverage that verifies detector span scans do not overlap.

## Why

Long OpenWebUI chat histories can produce many scanned text spans. The Python detector serializes GLiNER inference internally, so concurrent proxy-side `/analyze` calls can queue behind that lock while each client-side 30s timeout is already running. Later queued calls can time out and turn the proxy request into a 503.

## Validation

- `bun test`
- `bun run typecheck`
- `bun run check`
- Live run with real detector on `127.0.0.1:5002`, PasteGuard `/openai/v1/chat/completions`, and a fake local OpenAI-compatible provider. An 81-message OpenWebUI-shaped request returned 200 in about 5.5s, sent placeholders upstream, and restored the placeholder in the response.

Fixes #134
