### PR TITLE
Bump version to 0.7.4

### DIFF
--- a/docs/api-reference/status.mdx
+++ b/docs/api-reference/status.mdx
@@ -66,7 +66,7 @@ curl http://localhost:3000/info
 ```json
 {
   "name": "PasteGuard",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Privacy proxy for LLMs",
   "mode": "mask",
   "providers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## What changed

- Bump package version to 0.7.4.
- Update the documented `/info` version example to 0.7.4.

## Validation

- `bun test`
- `bun run typecheck`
- `bun run check`
