### PR TITLE
v0.8.0 Bump release version

### DIFF
--- a/docs/api-reference/status.mdx
+++ b/docs/api-reference/status.mdx
@@ -66,7 +66,7 @@ curl http://localhost:3000/info
 ```json
 {
   "name": "PasteGuard",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "Privacy proxy for LLMs",
   "mode": "mask",
   "providers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

Bumps PasteGuard to 0.8.0 after the OpenAI Responses protection landed in #142.
Updates the `/info` reference example to match the runtime version.

## Verification

- `bun test` — 421 passed, 1 skipped
- `bun run typecheck`
- `bun run check`
- `bun run build`
