### PR TITLE
Fix web security issues in dashboard, detector, and CORS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,18 @@ const requestIdMiddleware = createMiddleware<{ Variables: Variables }>(async (c,
 
 // Middleware
 app.use("*", requestIdMiddleware);
-app.use("*", cors());
+// Permissive CORS is applied to the proxy and mask APIs so browser-based clients
+// can call them, but NOT to the dashboard. The dashboard UI and its JSON APIs
+// (/dashboard, /dashboard/api/*) are served same-origin and may be
+// unauthenticated; a wildcard Access-Control-Allow-Origin there would let any
+// website the operator visits read logged request data cross-origin. Same-origin
+// dashboard use needs no CORS headers, so excluding it changes no legitimate flow.
+const corsMiddleware = cors();
+app.use("*", (c, next) =>
+  c.req.path === "/dashboard" || c.req.path.startsWith("/dashboard/")
+    ? next()
+    : corsMiddleware(c, next),
+);
 app.use("*", logger());
 
 // Favicon

--- a/src/secrets/patterns/env-vars.ts
+++ b/src/secrets/patterns/env-vars.ts
@@ -18,16 +18,21 @@ export const envVarsDetector: PatternDetector = {
 
     // Environment variable password patterns: _PASSWORD or _PWD suffix with value (8+ chars)
     // Case-insensitive for variable name, supports = and : assignment, quoted/unquoted values
+    // The variable-name run is length-bounded ({0,128}) so a long, non-matching
+    // run of word characters cannot force quadratic backtracking (ReDoS); real
+    // env var names are far shorter than this bound.
     if (enabledTypes.has("ENV_PASSWORD")) {
       const passwordPattern =
-        /[A-Za-z_][A-Za-z0-9_]*(?:PASSWORD|_PWD)\s*[=:]\s*['"]?[^\s'"]{8,}['"]?/gi;
+        /[A-Za-z_][A-Za-z0-9_]{0,128}(?:PASSWORD|_PWD)\s*[=:]\s*['"]?[^\s'"]{8,}['"]?/gi;
       detectPattern(text, passwordPattern, "ENV_PASSWORD", matches, locations);
     }
 
     // Environment variable secret patterns: _SECRET suffix with value (8+ chars)
     // Case-insensitive for variable name, supports = and : assignment, quoted/unquoted values
+    // The variable-name run is length-bounded ({0,128}) to prevent quadratic
+    // backtracking (ReDoS) on long non-matching word-character runs.
     if (enabledTypes.has("ENV_SECRET")) {
-      const secretPattern = /[A-Za-z_][A-Za-z0-9_]*_SECRET\s*[=:]\s*['"]?[^\s'"]{8,}['"]?/gi;
+      const secretPattern = /[A-Za-z_][A-Za-z0-9_]{0,128}_SECRET\s*[=:]\s*['"]?[^\s'"]{8,}['"]?/gi;
       detectPattern(text, secretPattern, "ENV_SECRET", matches, locations);
     }
 

--- a/src/views/dashboard/page.tsx
+++ b/src/views/dashboard/page.tsx
@@ -554,6 +554,15 @@ function renderEntityList(entities) {
   ).join('') + '</div>';
 }
 
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function formatSourceLabel(source) {
   return source === 'browser_extension' ? 'Browser Extension' : source.toUpperCase();
 }
@@ -602,7 +611,7 @@ async function fetchLogs() {
           '</td>' +
           '<td class="text-sm px-4 py-3 border-b border-border-subtle align-middle">' + sourceBadge + '</td>' +
           '<td class="text-sm px-4 py-3 border-b border-border-subtle align-middle">' + statusBadge + '</td>' +
-          '<td class="font-mono text-[0.7rem] text-text-secondary px-4 py-3 border-b border-border-subtle align-middle">' + log.model + '</td>' +
+          '<td class="font-mono text-[0.7rem] text-text-secondary px-4 py-3 border-b border-border-subtle align-middle">' + escapeHtml(log.model) + '</td>' +
           '<td class="text-sm px-4 py-3 border-b border-border-subtle align-middle">' +
             (entities.length > 0
               ? '<div class="flex flex-wrap gap-1">' + entities.map(e => '<span class="font-mono text-[0.55rem] px-1.5 py-0.5 bg-elevated border border-border rounded-sm text-text-secondary">' + e.trim() + '</span>').join('') + '</div>'


### PR DESCRIPTION
Fixes three web security issues found while reviewing the proxy and dashboard.

## Changes

**Stored XSS in the dashboard (high)**
The dashboard logs table rendered the client-supplied `model` string into the DOM via `innerHTML` without escaping. Since the proxy adds no client auth, any client able to reach it could store markup that executes when the operator opens the dashboard and read logged request content. Added an `escapeHtml` helper and escaped `log.model` before insertion.

**ReDoS in the env-var secret regexes (medium)**
`ENV_PASSWORD` and `ENV_SECRET` used an unbounded `[A-Za-z0-9_]*` run before a required literal, causing quadratic backtracking. Secrets detection runs synchronously on request text before forwarding, so a single long input could pin a CPU. Bounded the run to `{0,128}`; worst case for a 200k-char input drops from ~38s to ~50ms and detection is preserved for realistic variable names.

**Wildcard CORS on the dashboard API (medium)**
The global `app.use("*", cors())` sent `Access-Control-Allow-Origin: *` on the dashboard's unauthenticated JSON APIs, letting any site the operator visits read logged request data cross-origin. Excluded `/dashboard` routes from CORS while keeping it for the proxy and mask APIs. Note: this closes the browser cross-origin read; enabling dashboard auth and binding to localhost remain the fix for direct network access.

## Verification
- `bun run typecheck` — clean
- `bun run check` — clean
- `bun test` — 421 pass, 1 skip, 0 fail