### PR TITLE
Bump version to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Changes

- bump PasteGuard to 0.8.2 for the neutral container runtime release

## Verification

- `bun test`
- `bun run typecheck`
- `bun run typecheck:benchmarks`
- `bun run check`
- `bun run build`
- detector lint, format, type, and test checks
- arm64 and amd64 image builds
- `/info` reports `0.8.2` on both architectures