### PR TITLE
Use named Conductor development run

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -19,7 +19,14 @@ mv "$tmp" config.yaml
 
 mkdir -p data
 """
-run = """
+archive = """
+PORT="${CONDUCTOR_PORT:-3000}"
+docker compose -p "pasteguard-${PORT}" --profile dev down --remove-orphans || true
+"""
+run_mode = "concurrent"
+
+[scripts.run.dev]
+command = """
 set -e
 
 PORT="${CONDUCTOR_PORT:-3000}"
@@ -30,8 +37,5 @@ export DETECTOR_URL="http://localhost:${PASTEGUARD_DETECTOR_PORT}"
 docker compose -p "pasteguard-${PORT}" --profile dev up detector -d
 bun run dev
 """
-archive = """
-PORT="${CONDUCTOR_PORT:-3000}"
-docker compose -p "pasteguard-${PORT}" --profile dev down --remove-orphans || true
-"""
-run_mode = "concurrent"
+default = true
+icon = "play"


### PR DESCRIPTION
Conductor was starting stale legacy run metadata that referenced outdated service and port behavior. This registers the existing workspace-safe command as an explicit named default `dev` run so Conductor selects the detector-aware setup with isolated ports. Verified with `bun test` (421 passed, 1 skipped), `bun run typecheck`, `bun run check`, TOML and shell syntax checks, and a successful Conductor launch on port 55050.
