### PR TITLE
Fix container security findings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,9 @@
       },
     },
   },
+  "overrides": {
+    "postcss": "8.5.18",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -153,7 +156,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,8 @@
 #     pasteguard:latest
 
 ARG BUN_IMAGE=oven/bun:1-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04
-ARG PYTHON_BUILD_IMAGE=cgr.dev/chainguard/python:latest-dev@sha256:967409cf4148210d7c1bb872ffdda42a8b73cfc738f95eae7413045d0d6c30ee
-ARG PYTHON_RUNTIME_IMAGE=cgr.dev/chainguard/python:latest@sha256:2c6a2e8bdeb1336cd8545d3586d1c1e5b4f7564ef00924b0447ebfbe57a549ee
+ARG PYTHON_BUILD_IMAGE=cgr.dev/chainguard/python:latest-dev@sha256:7a568bcee42666f73f041645a41c913ce1d442f4c24cf6019bc543a90820e531
+ARG PYTHON_RUNTIME_IMAGE=cgr.dev/chainguard/python:latest@sha256:a0365f7b90bf7b78a5e35f2709efb7c9263acf9c7b1905e0ec4c3e943c88e64d
 
 # =============================================================================
 # Stage: bun-builder — build the Bun application

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "@types/pg": "^8.20.0",
     "typescript": "^5.9.3"
   },
+  "overrides": {
+    "postcss": "8.5.18"
+  },
   "keywords": [
     "llm",
     "privacy",


### PR DESCRIPTION
## Changes

- refresh the pinned Chainguard Python build and runtime manifests so the runtime includes `python-3.14` and `python-3.14-base` 3.14.6-r4
- force the shipped PostCSS metadependency to 8.5.18 and update the Bun lockfile
- keep the application version at 0.8.2 so the 0.8.3 bump remains a separate release step

## Verification

- `bun install --frozen-lockfile --force`
- `bun run typecheck`
- `bun run typecheck:benchmarks`
- `bun run check`
- `bun test` (429 passed, 1 skipped)
- `bun run build`
- detector `pip check`, Ruff lint/format, Pyright, and Pytest (68 passed)
- local `linux/amd64` image build
- health, `/info`, PII masking, and OpenAI proxy round-trip smoke tests
- `/info` still reports 0.8.2
- runtime UID 65532 and missing `/bin/sh` confirmed
- Trivy HIGH/CRITICAL vulnerability scan: 0 findings
- Trivy secret scan: 0 findings
- explicit checks confirm `CVE-2026-15308` and `GHSA-r28c-9q8g-f849` are absent
- `git diff --check`
