### PR TITLE
Bump version to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

Bump the PasteGuard package version from 0.8.2 to 0.8.3 for the next patch release.

This release packages the fixes merged since v0.8.2, including detector-neutral error handling and regressions, container security updates, and preservation of sensitive fragments around placeholders.

## Validation

- `bun test` (437 passed, 1 skipped)
- `bun run typecheck`
- `bun run check`
- `bun run build`
