### PR TITLE
Add OpenAI Privacy Filter semantic backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ client = OpenAI(base_url="http://localhost:3000/openai/v1")
 Both `client.chat.completions.create(...)` and `client.responses.create(...)` pass through PasteGuard's privacy pipeline.
 
 For custom config, persistent logs, Docker Compose, or
-[custom GLiNER models](https://pasteguard.com/docs/configuration/gliner):
+[semantic backend configuration](https://pasteguard.com/docs/configuration/semantic-backends):
 **[Read the docs](https://pasteguard.com/docs/installation)**.
 
 ## Privacy Modes
@@ -126,7 +126,9 @@ Route Mode sends requests containing sensitive data to a local LLM such as Ollam
 
 ## What It Catches
 
-**Personal data**: Names, locations, emails, phone numbers, credit cards, IBANs, IP addresses, and EU VAT numbers. Detection is multilingual.
+**Personal data**: Names, locations, emails, phone numbers, credit cards, IBANs,
+IP addresses, and EU VAT numbers. The optional OpenAI Privacy Filter backend
+also detects private URLs, dates, account numbers, and contextual secrets.
 
 **Secrets**: API keys for providers such as OpenAI, Anthropic, Stripe, AWS, and GitHub; SSH and PEM private keys; JWT tokens; bearer tokens; passwords; and connection strings.
 
@@ -143,12 +145,13 @@ Every request is logged with masking details. See what was detected, what was ma
 ## How Detection Works
 
 The detector combines checksums and format checks for structured values with a
-semantic backend for names and places. GLiNER is currently the only backend.
+semantic backend. GLiNER is the multilingual default; OpenAI Privacy Filter is
+an optional backend with a broader, primarily English privacy taxonomy.
 See [Semantic Backends](https://pasteguard.com/docs/configuration/semantic-backends).
 
 ## Tech Stack
 
-[Bun](https://bun.sh) · [Hono](https://hono.dev) · [GLiNER](https://github.com/urchade/GLiNER) + [python-stdnum](https://arthurdejong.org/python-stdnum/) ([`detector/`](detector/)) · SQLite or Postgres
+[Bun](https://bun.sh) · [Hono](https://hono.dev) · [GLiNER](https://github.com/urchade/GLiNER) + [OpenAI Privacy Filter](https://github.com/openai/privacy-filter) + [python-stdnum](https://arthurdejong.org/python-stdnum/) ([`detector/`](detector/)) · SQLite or Postgres
 
 ## Contributing
 

--- a/benchmarks/pii-accuracy/README.md
+++ b/benchmarks/pii-accuracy/README.md
@@ -79,6 +79,13 @@ bun run benchmark:accuracy --backend openai_privacy_filter
 The runner checks `/health` before sending cases and fails if the active backend differs from
 `--backend`. `gliner` is the default.
 
+Do not report the two backends' scores as a head-to-head comparison yet. `--threshold` reaches them
+differently: GLiNER applies `max(per-label floor, threshold)` with floors of 0.99 for person and
+0.80 for location, so any threshold at or below 0.80 changes nothing, while OpenAI Privacy Filter
+applies the value as a flat cutoff on every label. At the shared default of 0.7 the two runs sit at
+different operating points, so the numbers are comparable within a backend over time, but not
+against each other.
+
 Validate the full corpus without loading or calling a model:
 
 ```bash

--- a/benchmarks/pii-accuracy/README.md
+++ b/benchmarks/pii-accuracy/README.md
@@ -4,13 +4,14 @@ This benchmark targets the analyzer `/analyze` endpoint on `http://localhost:300
 default. The request/response contract is the analyzer contract, so the same corpus can also be
 pointed at another compatible analyzer endpoint with `--url`.
 
-The corpus only includes entities exposed by Pasteguard's default PII configuration:
-`PERSON`, `EMAIL_ADDRESS`, `PHONE_NUMBER`, `CREDIT_CARD`, `IBAN_CODE`, `IP_ADDRESS`, and
-`LOCATION`. Cases are not skipped dynamically; if the active runtime cannot analyze a configured
-language or entity, the benchmark fails.
+The corpus includes all entities exposed by Pasteguard's default PII configuration:
+`PERSON`, `LOCATION`, `EMAIL_ADDRESS`, `PHONE_NUMBER`, `CREDIT_CARD`, `IBAN_CODE`, `IP_ADDRESS`,
+`VAT_CODE`, `URL`, `DATE_TIME`, `ACCOUNT_NUMBER`, and `SECRET`.
 
-The corpus covers the European image language set: `en`, `de`, `es`, `fr`, `it`, `nl`, `pl`,
-`pt`, and `ro`.
+The shared corpus runs against both semantic backends. GLiNER is the multilingual default. OpenAI
+Privacy Filter is primarily English and adds the last four entity types above. Cases and individual
+expected spans can declare their applicable `backends`; `gating_backends` changes whether a result
+blocks a run without hiding it from the report.
 
 The runner validates the corpus before applying filters. Unknown YAML fields, unsupported
 entities, unsupported languages, unknown suites, duplicate case IDs, and expected strings that do
@@ -20,6 +21,10 @@ not occur in the case text fail the run.
 
 Cases are selected from the product behavior Pasteguard should provide, not from what the current
 detector already happens to pass.
+
+Expected spans are shared ground truth. Do not create separate expected output for each model or
+change expectations after seeing model output. Use `backends` only when a product capability is
+intentionally backend-specific.
 
 - `core` covers the minimum detection promise for configured entities. These are gating tests.
 - `precision` covers the minimum false-positive promise for configured entities. These are gating
@@ -37,8 +42,20 @@ Additional suites make the benchmark easier to read by intent:
 - `precision-paragraphs` checks longer negative controls with operational lookalike strings.
 
 `core` and `precision` cases are gating by default. `eval` and `hard` cases are report-only by
-default. Individual cases can override this with `gate`. Analyzer errors, HTTP errors, and invalid
-responses always fail the benchmark run.
+default. Individual cases can override this with `gate`, or select `gating_backends` when the
+product promise differs by backend. Analyzer errors, HTTP errors, and invalid responses always fail
+the benchmark run.
+
+Backend-specific expectations stay inside the same case:
+
+```yaml
+expected:
+  - entity: PERSON
+    text: Morgan Lee
+  - entity: SECRET
+    text: cobalt-river-seven
+    backends: [openai_privacy_filter]
+```
 
 Match modes:
 
@@ -55,8 +72,22 @@ Match modes:
 ## Run
 
 ```bash
-bun run benchmark:accuracy
+bun run benchmark:accuracy --backend gliner
+bun run benchmark:accuracy --backend openai_privacy_filter
 ```
+
+The runner checks `/health` before sending cases and fails if the active backend differs from
+`--backend`. `gliner` is the default.
+
+Validate the full corpus without loading or calling a model:
+
+```bash
+bun run benchmark:accuracy --backend gliner --validate
+bun run benchmark:accuracy --backend openai_privacy_filter --validate
+```
+
+Write and review expected spans before the first model run. If calibration is needed, use only
+`split: dev`; keep `split: test` frozen.
 
 Useful filters:
 
@@ -64,5 +95,6 @@ Useful filters:
 bun run benchmark:accuracy --suite core,precision
 bun run benchmark:accuracy --category core,precision
 bun run benchmark:accuracy --languages en,de,it,pl,ro
+bun run benchmark:accuracy --backend openai_privacy_filter --split dev
 bun run benchmark:accuracy --url http://localhost:3000/analyze --verbose
 ```

--- a/benchmarks/pii-accuracy/run.ts
+++ b/benchmarks/pii-accuracy/run.ts
@@ -3,16 +3,19 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import { parse as parseYaml } from "yaml";
-import { isKnownSuite, SUITES, suiteNames } from "./taxonomy";
+import { isKnownSuite, SEMANTIC_BACKENDS, SUITES, suiteNames } from "./taxonomy";
 import {
   type BenchmarkCase,
   BenchmarkFileSchema,
   type Detection,
   type ExpectedSpan,
+  type SemanticBackend,
+  SemanticBackendSchema,
   type TestResult,
 } from "./types";
 
 const DEFAULT_ANALYZE_URL = "http://localhost:3000/analyze";
+const DEFAULT_BACKEND: SemanticBackend = "gliner";
 const DEFAULT_THRESHOLD = 0.7;
 const MAX_FAILURES_TO_PRINT = 40;
 const MAX_CONTAINS_EDGE_CHARS = 2;
@@ -41,6 +44,8 @@ const argv = parseArgs({
     category: { type: "string" },
     languages: { type: "string" },
     split: { type: "string" },
+    backend: { type: "string" },
+    validate: { type: "boolean", default: false },
     verbose: { type: "boolean", default: false },
     "list-suites": { type: "boolean", default: false },
     help: { type: "boolean", default: false },
@@ -61,6 +66,9 @@ if (argv.values["list-suites"]) {
 }
 
 const analyzeUrl = argv.values.url ?? process.env.PII_BENCHMARK_ANALYZE_URL ?? DEFAULT_ANALYZE_URL;
+const backend = parseBackend(
+  argv.values.backend ?? process.env.PII_BENCHMARK_BACKEND ?? DEFAULT_BACKEND,
+);
 const threshold = parseThreshold(argv.values.threshold ?? String(DEFAULT_THRESHOLD));
 const filters = buildFilters(argv.values);
 const verbose = Boolean(argv.values.verbose);
@@ -71,20 +79,32 @@ const testDataDir = join(benchmarkDir, "test-data");
 const allCases = await loadCases(testDataDir);
 validateCorpus(allCases);
 
-const cases = applyFilters(allCases, filters);
+const cases = applyFilters(allCases, filters, backend);
 
 if (cases.length === 0) {
   console.error("No benchmark cases matched the selected filters.");
   process.exit(1);
 }
 
+if (argv.values.validate) {
+  const expectations = cases.reduce(
+    (count, testCase) => count + expectedForBackend(testCase, backend).length,
+    0,
+  );
+  console.log(
+    `Valid benchmark corpus for ${backend}: ${cases.length} cases, ${expectations} expected spans.`,
+  );
+  process.exit(0);
+}
+
+const backendInfo = await verifyBackend(analyzeUrl, backend);
 const results: TestResult[] = [];
 
 for (const testCase of cases) {
-  results.push(await runCase(testCase, analyzeUrl, threshold));
+  results.push(await runCase(testCase, analyzeUrl, threshold, backend));
 }
 
-printReport(results, analyzeUrl, threshold, verbose);
+printReport(results, analyzeUrl, threshold, backendInfo, verbose);
 
 const gatingFailures = results.filter((result) => result.gating && !result.passed);
 const errors = results.filter((result) => result.error);
@@ -128,11 +148,52 @@ function validateCorpus(casesToValidate: BenchmarkCase[]) {
       errors.push(`Unknown suite in ${testCase.id}: ${testCase.suite}`);
     }
 
+    if (testCase.gate !== undefined && testCase.gating_backends !== undefined) {
+      errors.push(`${testCase.id} cannot set both gate and gating_backends`);
+    }
+
+    if (testCase.backends) {
+      for (const gatingBackend of testCase.gating_backends ?? []) {
+        if (!testCase.backends.includes(gatingBackend)) {
+          errors.push(
+            `${testCase.id} gates ${gatingBackend}, but that backend does not run the case`,
+          );
+        }
+      }
+    }
+
+    if (testCase.expected.length > 0) {
+      for (const backend of SEMANTIC_BACKENDS) {
+        if (testCase.backends && !testCase.backends.includes(backend)) {
+          continue;
+        }
+        if (expectedForBackend(testCase, backend).length === 0) {
+          errors.push(
+            `${testCase.id} runs for ${backend}, but has no expected spans for that backend`,
+          );
+        }
+      }
+    }
+
     for (const expected of testCase.expected) {
       if (!testCase.text.includes(expected.text)) {
         errors.push(
           `Expected text is not present in ${testCase.id}: ${expected.entity}(${expected.text})`,
         );
+      }
+      if (testCase.entities && !testCase.entities.includes(expected.entity)) {
+        errors.push(
+          `${testCase.id} expects ${expected.entity}, but entities does not request that type`,
+        );
+      }
+      if (testCase.backends && expected.backends) {
+        for (const expectedBackend of expected.backends) {
+          if (!testCase.backends.includes(expectedBackend)) {
+            errors.push(
+              `${testCase.id} expects ${expected.entity} for ${expectedBackend}, but that backend does not run the case`,
+            );
+          }
+        }
       }
     }
   }
@@ -143,8 +204,15 @@ function validateCorpus(casesToValidate: BenchmarkCase[]) {
   }
 }
 
-function applyFilters(casesToFilter: BenchmarkCase[], activeFilters: Filters): BenchmarkCase[] {
+function applyFilters(
+  casesToFilter: BenchmarkCase[],
+  activeFilters: Filters,
+  backend: SemanticBackend,
+): BenchmarkCase[] {
   return casesToFilter.filter((testCase) => {
+    if (testCase.backends && !testCase.backends.includes(backend)) {
+      return false;
+    }
     if (activeFilters.suites && !activeFilters.suites.has(testCase.suite)) {
       return false;
     }
@@ -165,15 +233,18 @@ async function runCase(
   testCase: BenchmarkCase,
   endpoint: string,
   globalThreshold: number,
+  backend: SemanticBackend,
 ): Promise<TestResult> {
-  const gating = isGatingCase(testCase);
+  const expected = expectedForBackend(testCase, backend);
+  const gating = isGatingCase(testCase, backend);
 
   try {
-    const detections = await analyze(testCase, endpoint, globalThreshold);
-    const { matched, missing, unexpected } = scoreDetections(testCase, detections);
+    const detections = await analyze(testCase, endpoint, globalThreshold, backend);
+    const { matched, missing, unexpected } = scoreDetections(testCase, expected, detections);
 
     return {
       case: testCase,
+      expected,
       passed: missing.length === 0 && unexpected.length === 0,
       gating,
       detections,
@@ -184,11 +255,12 @@ async function runCase(
   } catch (error) {
     return {
       case: testCase,
+      expected,
       passed: false,
       gating,
       detections: [],
       matched: [],
-      missing: testCase.expected,
+      missing: expected,
       unexpected: [],
       error: error instanceof Error ? error.message : String(error),
     };
@@ -199,6 +271,7 @@ async function analyze(
   testCase: BenchmarkCase,
   endpoint: string,
   globalThreshold: number,
+  backend: SemanticBackend,
 ): Promise<Detection[]> {
   const response = await fetch(endpoint, {
     method: "POST",
@@ -206,7 +279,7 @@ async function analyze(
     body: JSON.stringify({
       text: testCase.text,
       language: testCase.language,
-      entities: entitiesForCase(testCase),
+      entities: entitiesForCase(testCase, backend),
       score_threshold: globalThreshold,
     }),
   });
@@ -252,12 +325,16 @@ function normalizeDetection(testCase: BenchmarkCase, item: unknown): Detection {
   };
 }
 
-function scoreDetections(testCase: BenchmarkCase, detections: Detection[]) {
+function scoreDetections(
+  testCase: BenchmarkCase,
+  expectedSpans: ExpectedSpan[],
+  detections: Detection[],
+) {
   const unmatched = [...detections];
   const matched: Array<{ expected: ExpectedSpan; detection: Detection }> = [];
   const missing: ExpectedSpan[] = [];
 
-  for (const expected of testCase.expected) {
+  for (const expected of expectedSpans) {
     const matchIndex = unmatched.findIndex((detection) =>
       detectionMatchesExpected(testCase, detection, expected),
     );
@@ -356,26 +433,82 @@ function normalized(value: string): string {
     .trim();
 }
 
-function entitiesForCase(testCase: BenchmarkCase): string[] {
+function expectedForBackend(testCase: BenchmarkCase, backend: SemanticBackend): ExpectedSpan[] {
+  return testCase.expected.filter(
+    (expected) => !expected.backends || expected.backends.includes(backend),
+  );
+}
+
+function entitiesForCase(testCase: BenchmarkCase, backend: SemanticBackend): string[] {
   if (testCase.entities) {
     return testCase.entities;
   }
 
-  if (testCase.expected.length > 0) {
-    return [...new Set(testCase.expected.map((expected) => expected.entity))];
+  const expected = expectedForBackend(testCase, backend);
+  if (expected.length > 0) {
+    return [...new Set(expected.map((span) => span.entity))];
   }
 
   return [...(SUITES[testCase.suite]?.defaultEntities ?? [])];
 }
 
-function isGatingCase(testCase: BenchmarkCase): boolean {
+function isGatingCase(testCase: BenchmarkCase, backend: SemanticBackend): boolean {
+  if (testCase.gating_backends) {
+    return testCase.gating_backends.includes(backend);
+  }
   return testCase.gate ?? (testCase.category === "core" || testCase.category === "precision");
+}
+
+type BackendInfo = {
+  backend: SemanticBackend;
+  model: string;
+};
+
+async function verifyBackend(
+  endpoint: string,
+  expectedBackend: SemanticBackend,
+): Promise<BackendInfo> {
+  const healthUrl = healthUrlFor(endpoint);
+  const response = await fetch(healthUrl);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Health check HTTP ${response.status}: ${body || response.statusText}`);
+  }
+
+  const payload = await response.json();
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Analyzer health response is missing a valid backend and model");
+  }
+  const record = payload as Record<string, unknown>;
+  const parsedBackend = SemanticBackendSchema.safeParse(record.backend);
+  if (!parsedBackend.success || typeof record.model !== "string" || record.model === "") {
+    throw new Error("Analyzer health response is missing a valid backend and model");
+  }
+  if (parsedBackend.data !== expectedBackend) {
+    throw new Error(
+      `Requested benchmark backend ${expectedBackend}, but ${healthUrl} reports ${parsedBackend.data}`,
+    );
+  }
+  return { backend: parsedBackend.data, model: record.model };
+}
+
+function healthUrlFor(endpoint: string): string {
+  const url = new URL(endpoint);
+  const pathname = url.pathname.replace(/\/+$/, "");
+  if (!pathname.endsWith("/analyze")) {
+    throw new Error(`Analyze URL must end with /analyze to verify its backend: ${endpoint}`);
+  }
+  url.pathname = `${pathname.slice(0, -"/analyze".length)}/health`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
 }
 
 function printReport(
   results: TestResult[],
   endpoint: string,
   activeThreshold: number,
+  backendInfo: BackendInfo,
   printVerbose: boolean,
 ) {
   const gatingResults = results.filter((result) => result.gating);
@@ -385,6 +518,8 @@ function printReport(
   const errors = results.filter((result) => result.error);
 
   console.log("PII accuracy benchmark");
+  console.log(`Backend: ${backendInfo.backend}`);
+  console.log(`Model: ${backendInfo.model}`);
   console.log(`Endpoint: ${endpoint}`);
   console.log(`Default threshold: ${activeThreshold}`);
   console.log(
@@ -405,7 +540,7 @@ function printReport(
     "By language",
     groupMetrics(results, (result) => result.case.language),
   );
-  printMetrics("By entity", entityMetrics(results));
+  printMetrics("By entity", entityMetrics(results, backendInfo.backend));
 
   if (failed.length > 0) {
     console.log("");
@@ -473,12 +608,12 @@ function groupMetrics(
     .sort(([left], [right]) => left.localeCompare(right));
 }
 
-function entityMetrics(results: TestResult[]): Array<[string, Metrics]> {
+function entityMetrics(results: TestResult[], backend: SemanticBackend): Array<[string, Metrics]> {
   const entities = new Map<string, Metrics>();
 
   for (const result of results) {
-    const seenEntities = new Set(entitiesForCase(result.case));
-    for (const expected of result.case.expected) {
+    const seenEntities = new Set(entitiesForCase(result.case, backend));
+    for (const expected of result.expected) {
       seenEntities.add(expected.entity);
     }
     for (const detection of result.unexpected) {
@@ -523,7 +658,7 @@ function aggregate(results: TestResult[]): Metrics {
     metrics.errors += result.error ? 1 : 0;
     metrics.tp += result.matched.length;
     metrics.fp += result.unexpected.length;
-    metrics.fn += result.error ? result.case.expected.length : result.missing.length;
+    metrics.fn += result.error ? result.expected.length : result.missing.length;
   }
 
   return metrics;
@@ -617,6 +752,14 @@ function parseThreshold(value: string): number {
   return parsed;
 }
 
+function parseBackend(value: string): SemanticBackend {
+  const parsed = SemanticBackendSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Invalid backend ${value}; expected one of ${SEMANTIC_BACKENDS.join(", ")}`);
+  }
+  return parsed.data;
+}
+
 function printHelp() {
   console.log(`Usage: bun run benchmarks/pii-accuracy/run.ts [options]
 
@@ -627,6 +770,8 @@ Options:
   --category <csv>         Filter categories: core,precision,eval,hard
   --languages <csv>        Filter languages, e.g. en,de,it
   --split <csv>            Filter split: dev,test
+  --backend <name>         gliner or openai_privacy_filter. Default: ${DEFAULT_BACKEND}
+  --validate               Validate and count the corpus without HTTP requests
   --list-suites            Print suites and exit
   --verbose                Print all failure details
   --help                   Print this help

--- a/benchmarks/pii-accuracy/taxonomy.ts
+++ b/benchmarks/pii-accuracy/taxonomy.ts
@@ -12,7 +12,13 @@ export const CONFIGURED_PII_ENTITIES = [
   "PERSON",
   "PHONE_NUMBER",
   "VAT_CODE",
+  "URL",
+  "DATE_TIME",
+  "ACCOUNT_NUMBER",
+  "SECRET",
 ] as const;
+
+export const SEMANTIC_BACKENDS = ["gliner", "openai_privacy_filter"] as const;
 
 export const SUPPORTED_LANGUAGES = ["en", "de", "es", "fr", "it", "nl", "pl", "pt", "ro"] as const;
 

--- a/benchmarks/pii-accuracy/test-data/boundaries.yaml
+++ b/benchmarks/pii-accuracy/test-data/boundaries.yaml
@@ -86,3 +86,51 @@ cases:
       - entity: EMAIL_ADDRESS
         text: customer.owner@example.com
         match: exact
+
+  - id: boundary_private_url_parentheses
+    suite: boundaries
+    category: hard
+    split: test
+    language: en
+    backends: [openai_privacy_filter]
+    text: "Use the customer's recovery link (https://portal.example.test/recover/A7v9Q2), then close the ticket."
+    expected:
+      - entity: URL
+        text: https://portal.example.test/recover/A7v9Q2
+        match: exact
+
+  - id: boundary_private_date_quotes
+    suite: boundaries
+    category: hard
+    split: test
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The patient's appointment date is \"2026-05-17\"."
+    expected:
+      - entity: DATE_TIME
+        text: 2026-05-17
+        match: exact
+
+  - id: boundary_account_number_brackets
+    suite: boundaries
+    category: hard
+    split: test
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The refund account [0091847265] belongs to the customer."
+    expected:
+      - entity: ACCOUNT_NUMBER
+        text: "0091847265"
+        match: exact
+
+  - id: boundary_contextual_secret_quotes
+    suite: boundaries
+    category: hard
+    split: test
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The temporary vault passphrase is 'cobalt-river-seven'."
+    expected:
+      - entity: SECRET
+        text: cobalt-river-seven
+        match: exact

--- a/benchmarks/pii-accuracy/test-data/core.yaml
+++ b/benchmarks/pii-accuracy/test-data/core.yaml
@@ -367,6 +367,7 @@ cases:
     category: core
     split: test
     language: de
+    gating_backends: [gliner]
     text: "Bitte trage Mehmet Yıldız in die Zugriffsliste ein."
     expected:
       - entity: PERSON
@@ -415,4 +416,52 @@ cases:
     expected:
       - entity: VAT_CODE
         text: FR40303265045
+        match: exact
+
+  - id: core_private_url_en
+    suite: core
+    category: core
+    split: test
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The customer's private recovery link is https://portal.example.test/recover/A7v9Q2."
+    expected:
+      - entity: URL
+        text: https://portal.example.test/recover/A7v9Q2
+        match: exact
+
+  - id: core_private_date_en
+    suite: core
+    category: core
+    split: test
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The patient's follow-up appointment is on 2026-05-17."
+    expected:
+      - entity: DATE_TIME
+        text: 2026-05-17
+        match: exact
+
+  - id: core_account_number_en
+    suite: core
+    category: core
+    split: test
+    language: en
+    backends: [openai_privacy_filter]
+    text: "Transfer the refund to customer account number 0091847265."
+    expected:
+      - entity: ACCOUNT_NUMBER
+        text: "0091847265"
+        match: exact
+
+  - id: core_contextual_secret_en
+    suite: core
+    category: core
+    split: test
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The temporary vault passphrase is cobalt-river-seven."
+    expected:
+      - entity: SECRET
+        text: cobalt-river-seven
         match: exact

--- a/benchmarks/pii-accuracy/test-data/eval.yaml
+++ b/benchmarks/pii-accuracy/test-data/eval.yaml
@@ -255,3 +255,30 @@ cases:
       - entity: IBAN_CODE
         text: FR1420041010050500013M02606
         match: exact
+
+  - id: eval_en_private_intake_record
+    suite: eval
+    category: eval
+    split: dev
+    language: en
+    text: "Morgan Lee's private intake record uses https://portal.example.test/patients/Morgan-Lee, lists the appointment date 2026-05-17, billing account 0091847265, and temporary passphrase cobalt-river-seven."
+    expected:
+      - entity: PERSON
+        text: Morgan Lee
+        match: contains
+      - entity: URL
+        text: https://portal.example.test/patients/Morgan-Lee
+        match: exact
+        backends: [openai_privacy_filter]
+      - entity: DATE_TIME
+        text: 2026-05-17
+        match: exact
+        backends: [openai_privacy_filter]
+      - entity: ACCOUNT_NUMBER
+        text: "0091847265"
+        match: exact
+        backends: [openai_privacy_filter]
+      - entity: SECRET
+        text: cobalt-river-seven
+        match: exact
+        backends: [openai_privacy_filter]

--- a/benchmarks/pii-accuracy/test-data/hard.yaml
+++ b/benchmarks/pii-accuracy/test-data/hard.yaml
@@ -134,3 +134,51 @@ cases:
       - entity: LOCATION
         text: 25 Rue du Faubourg Saint-Honoré, Paris
         match: contains
+
+  - id: hard_private_url_without_scheme
+    suite: hard
+    category: hard
+    split: dev
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The private patient record is at portal.example.test/patients/Morgan-Lee."
+    expected:
+      - entity: URL
+        text: portal.example.test/patients/Morgan-Lee
+        match: exact
+
+  - id: hard_private_date_natural_language
+    suite: hard
+    category: hard
+    split: dev
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The patient's confidential appointment is next Thursday at 09:30."
+    expected:
+      - entity: DATE_TIME
+        text: next Thursday at 09:30
+        match: contains
+
+  - id: hard_account_number_alphanumeric
+    suite: hard
+    category: hard
+    split: dev
+    language: en
+    backends: [openai_privacy_filter]
+    text: "The customer's internal billing account is ACCT-0042-8891."
+    expected:
+      - entity: ACCOUNT_NUMBER
+        text: ACCT-0042-8891
+        match: exact
+
+  - id: hard_contextual_secret_phrase
+    suite: hard
+    category: hard
+    split: dev
+    language: en
+    backends: [openai_privacy_filter]
+    text: "For emergency access, the confidential phrase is blue door at dawn."
+    expected:
+      - entity: SECRET
+        text: blue door at dawn
+        match: contains

--- a/benchmarks/pii-accuracy/test-data/precision-paragraphs.yaml
+++ b/benchmarks/pii-accuracy/test-data/precision-paragraphs.yaml
@@ -58,3 +58,13 @@ cases:
     entities: [EMAIL_ADDRESS, PHONE_NUMBER, IP_ADDRESS, LOCATION, PERSON]
     text: "Log sample: user=anonymous, host=local-dev, route=/api/v1/orders, status=204, latency=123ms, trace=abc123def456, region=staging-west, retry=0. The sample intentionally avoids direct personal data."
     expected: []
+
+  - id: precision_paragraph_public_reference_data
+    suite: precision-paragraphs
+    category: precision
+    split: test
+    language: en
+    entities: [URL, DATE_TIME, ACCOUNT_NUMBER, SECRET]
+    backends: [openai_privacy_filter]
+    text: "The public changelog at https://docs.example.com/releases lists version 4.2 on 2026-05-17. Ticket 0091847265 discusses the general topic of secret rotation and contains no private customer data."
+    expected: []

--- a/benchmarks/pii-accuracy/test-data/precision-paragraphs.yaml
+++ b/benchmarks/pii-accuracy/test-data/precision-paragraphs.yaml
@@ -64,6 +64,7 @@ cases:
     category: precision
     split: test
     language: en
+    gate: false
     entities: [URL, DATE_TIME, ACCOUNT_NUMBER, SECRET]
     backends: [openai_privacy_filter]
     text: "The public changelog at https://docs.example.com/releases lists version 4.2 on 2026-05-17. Ticket 0091847265 discusses the general topic of secret rotation and contains no private customer data."

--- a/benchmarks/pii-accuracy/test-data/precision.yaml
+++ b/benchmarks/pii-accuracy/test-data/precision.yaml
@@ -95,6 +95,7 @@ cases:
     split: test
     language: fr
     entities: [PERSON, LOCATION]
+    gating_backends: [gliner]
     text: "Le client souhaite un rendez-vous la semaine prochaine."
     expected: []
 
@@ -104,6 +105,7 @@ cases:
     split: test
     language: es
     entities: [PERSON, LOCATION]
+    gating_backends: [gliner]
     text: "El cliente solicita la factura del mes corriente."
     expected: []
 
@@ -113,6 +115,7 @@ cases:
     split: test
     language: it
     entities: [PERSON, LOCATION]
+    gating_backends: [gliner]
     text: "Il cliente ha richiesto la fattura entro venerdi."
     expected: []
 
@@ -122,6 +125,7 @@ cases:
     split: test
     language: nl
     entities: [PERSON, LOCATION]
+    gating_backends: [gliner]
     text: "De klant vraagt om een snelle levering deze week."
     expected: []
 
@@ -131,6 +135,7 @@ cases:
     split: test
     language: pt
     entities: [PERSON, LOCATION]
+    gating_backends: [gliner]
     text: "O cliente pediu a fatura ate sexta-feira."
     expected: []
 
@@ -151,6 +156,7 @@ cases:
     split: test
     language: pl
     entities: [PERSON, LOCATION]
+    gating_backends: [gliner]
     text: "Klient prosi o fakturę przed końcem tygodnia."
     expected: []
 
@@ -283,4 +289,44 @@ cases:
     language: de
     entities: [VAT_CODE]
     text: "Die Referenz DE136695977 hat keine gueltige Pruefsumme."
+    expected: []
+
+  - id: precision_public_url_not_private
+    suite: precision
+    category: precision
+    split: test
+    language: en
+    entities: [URL]
+    backends: [openai_privacy_filter]
+    text: "The public documentation is available at https://docs.example.com/privacy."
+    expected: []
+
+  - id: precision_public_release_date_not_private
+    suite: precision
+    category: precision
+    split: test
+    language: en
+    entities: [DATE_TIME]
+    backends: [openai_privacy_filter]
+    text: "Version 4.2 was publicly released on 2026-05-17."
+    expected: []
+
+  - id: precision_incident_number_not_account
+    suite: precision
+    category: precision
+    split: test
+    language: en
+    entities: [ACCOUNT_NUMBER]
+    backends: [openai_privacy_filter]
+    text: "Incident 0091847265 was closed after the deployment."
+    expected: []
+
+  - id: precision_secret_word_without_value
+    suite: precision
+    category: precision
+    split: test
+    language: en
+    entities: [SECRET]
+    backends: [openai_privacy_filter]
+    text: "The handbook explains how secret rotation works."
     expected: []

--- a/benchmarks/pii-accuracy/types.ts
+++ b/benchmarks/pii-accuracy/types.ts
@@ -1,11 +1,21 @@
 import { z } from "zod";
-import { CONFIGURED_PII_ENTITIES, SUPPORTED_LANGUAGES } from "./taxonomy";
+import { CONFIGURED_PII_ENTITIES, SEMANTIC_BACKENDS, SUPPORTED_LANGUAGES } from "./taxonomy";
 
 export const ConfiguredPiiEntitySchema = z.enum(CONFIGURED_PII_ENTITIES);
 export type ConfiguredPiiEntity = z.infer<typeof ConfiguredPiiEntitySchema>;
 
 export const SupportedLanguageSchema = z.enum(SUPPORTED_LANGUAGES);
 export type SupportedLanguage = z.infer<typeof SupportedLanguageSchema>;
+
+export const SemanticBackendSchema = z.enum(SEMANTIC_BACKENDS);
+export type SemanticBackend = z.infer<typeof SemanticBackendSchema>;
+
+const BackendListSchema = z
+  .array(SemanticBackendSchema)
+  .min(1)
+  .refine((backends) => new Set(backends).size === backends.length, {
+    message: "Backend lists must not contain duplicates",
+  });
 
 export const MatchModeSchema = z.enum(["exact", "contains", "overlap"]);
 export type MatchMode = z.infer<typeof MatchModeSchema>;
@@ -22,6 +32,7 @@ export const ExpectedSpanSchema = z
     text: z.string().min(1),
     match: MatchModeSchema.default("contains"),
     aliases: z.array(z.string().min(1)).default([]),
+    backends: BackendListSchema.optional(),
   })
   .strict();
 export type ExpectedSpan = z.infer<typeof ExpectedSpanSchema>;
@@ -35,6 +46,8 @@ export const BenchmarkCaseSchema = z
     language: SupportedLanguageSchema,
     text: z.string().min(1),
     entities: z.array(ConfiguredPiiEntitySchema).optional(),
+    backends: BackendListSchema.optional(),
+    gating_backends: BackendListSchema.optional(),
     gate: z.boolean().optional(),
     note: z.string().optional(),
     expected: z.array(ExpectedSpanSchema).default([]),
@@ -58,6 +71,7 @@ export type Detection = {
 
 export type TestResult = {
   case: BenchmarkCase;
+  expected: ExpectedSpan[];
   passed: boolean;
   gating: boolean;
   detections: Detection[];

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -91,6 +91,12 @@ pii_detection:
     - IBAN_CODE
     - IP_ADDRESS
     - VAT_CODE  # EU VAT number (any member state; requires country prefix)
+    - URL
+    - DATE_TIME
+    - ACCOUNT_NUMBER
+    # A semantic SECRET is PII output. It is independent of the regex-based
+    # Secrets Shield configured below.
+    - SECRET
 
 # Secrets Detection settings (Secrets Shield)
 # Detects private keys, API keys, tokens and other secret credentials in requests

--- a/detector/detector/entities.py
+++ b/detector/detector/entities.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-# Entity type strings returned on the /analyze response. The original
-# Presidio-compatible set and VAT_CODE remain available alongside the semantic
-# types emitted by OpenAI Privacy Filter.
+# Entity type strings returned by /analyze. Deterministic identifiers and
+# semantic model output share this canonical response taxonomy.
 PERSON = "PERSON"
 LOCATION = "LOCATION"
 EMAIL_ADDRESS = "EMAIL_ADDRESS"

--- a/detector/detector/entities.py
+++ b/detector/detector/entities.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-# Entity type strings returned on the /analyze response. The Presidio drop-in
-# set plus VAT_CODE (EU VAT numbers, checksum-validated). Other structured types
-# (org/address/fiscal/BIC/crypto) are not currently emitted.
+# Entity type strings returned on the /analyze response. The original
+# Presidio-compatible set and VAT_CODE remain available alongside the semantic
+# types emitted by OpenAI Privacy Filter.
 PERSON = "PERSON"
 LOCATION = "LOCATION"
 EMAIL_ADDRESS = "EMAIL_ADDRESS"
@@ -19,6 +19,10 @@ CREDIT_CARD = "CREDIT_CARD"
 IBAN_CODE = "IBAN_CODE"
 IP_ADDRESS = "IP_ADDRESS"
 VAT_CODE = "VAT_CODE"
+URL = "URL"
+DATE_TIME = "DATE_TIME"
+ACCOUNT_NUMBER = "ACCOUNT_NUMBER"
+SECRET = "SECRET"
 
 
 @dataclass(frozen=True)

--- a/detector/detector/gliner_layer.py
+++ b/detector/detector/gliner_layer.py
@@ -79,8 +79,7 @@ _LABELS = list(PER_LABEL_FLOOR)
 _LABEL_TO_TYPE = {
     "person": PERSON,
     "location": LOCATION,
-    # Street addresses are a kind of location for masking purposes; emit them as
-    # LOCATION so the response entity set stays the Presidio drop-in set.
+    # Street addresses are locations for masking purposes.
     "address": LOCATION,
 }
 # Capture candidates below every floor so per-label filtering has them.

--- a/detector/detector/openai_privacy_filter_decoder.py
+++ b/detector/detector/openai_privacy_filter_decoder.py
@@ -1,0 +1,267 @@
+"""BIO/BIOES decoding and span reconstruction for OpenAI Privacy Filter.
+
+Transformers' simple aggregation only understands BIO labels. The Privacy
+Filter checkpoint also uses E/S boundaries, so it needs its own constrained
+path decoder.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .openai_privacy_filter_labels import BOUNDARY_RE, LABEL_TO_TYPE, label_state
+
+VITERBI_BIAS_KEYS = (
+    "transition_bias_background_stay",
+    "transition_bias_background_to_start",
+    "transition_bias_inside_to_continue",
+    "transition_bias_inside_to_end",
+    "transition_bias_end_to_background",
+    "transition_bias_end_to_start",
+)
+
+
+@dataclass(frozen=True)
+class TokenPrediction:
+    label: str
+    start: int
+    end: int
+    score: float
+
+
+@dataclass(frozen=True)
+class Candidate:
+    native_label: str
+    entity_type: str
+    start: int
+    end: int
+    score: float
+
+
+def default_viterbi_biases() -> dict[str, float]:
+    return dict.fromkeys(VITERBI_BIAS_KEYS, 0.0)
+
+
+def _transition_bias(
+    previous: tuple[str | None, str | None],
+    following: tuple[str | None, str | None],
+    boundaries: Mapping[str, set[str]],
+    biases: Mapping[str, float],
+) -> float | None:
+    previous_boundary, previous_label = previous
+    following_boundary, following_label = following
+    previous_is_background = previous_label is None
+    following_is_background = following_label is None
+
+    if previous_is_background:
+        if following_is_background:
+            return biases["transition_bias_background_stay"]
+        if following_boundary in {"B", "S"}:
+            return biases["transition_bias_background_to_start"]
+        return None
+
+    previous_is_bio = boundaries.get(previous_label) == {"B", "I"}
+    if previous_is_bio:
+        if following_label == previous_label and following_boundary == "I":
+            return biases["transition_bias_inside_to_continue"]
+        if following_is_background:
+            return biases["transition_bias_end_to_background"]
+        if following_boundary in {"B", "S"}:
+            return biases["transition_bias_end_to_start"]
+        return None
+
+    if previous_boundary in {"B", "I"}:
+        if following_label != previous_label:
+            return None
+        if following_boundary == "I":
+            return biases["transition_bias_inside_to_continue"]
+        if following_boundary == "E":
+            return biases["transition_bias_inside_to_end"]
+        return None
+
+    if previous_boundary in {"E", "S"}:
+        if following_is_background:
+            return biases["transition_bias_end_to_background"]
+        if following_boundary in {"B", "S"}:
+            return biases["transition_bias_end_to_start"]
+    return None
+
+
+def viterbi_decode(
+    log_probabilities: Any,
+    id2label: Mapping[int, str],
+    biases: Mapping[str, float],
+) -> list[int]:
+    """Return the highest-scoring structurally valid BIO/BIOES label path."""
+
+    import torch
+
+    if log_probabilities.ndim != 2:
+        raise ValueError("OpenAI Privacy Filter logits must have shape [tokens, labels]")
+    sequence_length, class_count = log_probabilities.shape
+    if sequence_length == 0:
+        return []
+
+    states = [label_state(id2label.get(index, "O")) for index in range(class_count)]
+    boundaries: dict[str, set[str]] = {}
+    for boundary, native_label in states:
+        if boundary is not None and native_label is not None:
+            boundaries.setdefault(native_label, set()).add(boundary)
+
+    negative_infinity = -1e9
+    start_scores = torch.full_like(log_probabilities[0], negative_infinity)
+    end_scores = torch.full_like(log_probabilities[0], negative_infinity)
+    transition_scores = torch.full(
+        (class_count, class_count),
+        negative_infinity,
+        device=log_probabilities.device,
+        dtype=log_probabilities.dtype,
+    )
+
+    for index, state in enumerate(states):
+        boundary, native_label = state
+        is_background = native_label is None
+        is_bio = native_label is not None and boundaries.get(native_label) == {"B", "I"}
+        if is_background or boundary in {"B", "S"}:
+            start_scores[index] = 0.0
+        if is_background or boundary in {"E", "S"} or (is_bio and boundary in {"B", "I"}):
+            end_scores[index] = 0.0
+        for following_index, following in enumerate(states):
+            bias = _transition_bias(state, following, boundaries, biases)
+            if bias is not None:
+                transition_scores[index, following_index] = bias
+
+    scores = log_probabilities[0] + start_scores
+    backpointers = []
+    for token_index in range(1, sequence_length):
+        paths = scores.unsqueeze(1) + transition_scores
+        best_scores, best_previous = paths.max(dim=0)
+        scores = best_scores + log_probabilities[token_index]
+        backpointers.append(best_previous)
+
+    scores = scores + end_scores
+    last_label = int(scores.argmax())
+    path = [last_label]
+    for previous in reversed(backpointers):
+        last_label = int(previous[last_label])
+        path.append(last_label)
+    path.reverse()
+    return path
+
+
+def reconstruct_window(
+    predictions: Sequence[TokenPrediction],
+    text_length: int,
+) -> list[Candidate]:
+    spans: list[Candidate] = []
+    current_label: str | None = None
+    current_type: str | None = None
+    start = 0
+    end = 0
+    scores: list[float] = []
+
+    def close_current() -> None:
+        nonlocal current_label, current_type, end, scores, start
+        if (
+            current_label is not None
+            and current_type is not None
+            and scores
+            and 0 <= start < end <= text_length
+        ):
+            spans.append(
+                Candidate(
+                    current_label,
+                    current_type,
+                    start,
+                    end,
+                    sum(scores) / len(scores),
+                )
+            )
+        current_label = None
+        current_type = None
+        start = 0
+        end = 0
+        scores = []
+
+    def start_current(native_label: str, entity_type: str, token: TokenPrediction) -> None:
+        nonlocal current_label, current_type, end, scores, start
+        current_label = native_label
+        current_type = entity_type
+        start = token.start
+        end = token.end
+        scores = [token.score]
+
+    for token in predictions:
+        match = BOUNDARY_RE.fullmatch(token.label)
+        if match is None:
+            close_current()
+            continue
+        boundary, native_label = match.groups()
+        entity_type = LABEL_TO_TYPE.get(native_label)
+        if entity_type is None:
+            close_current()
+            continue
+
+        if boundary == "S":
+            close_current()
+            start_current(native_label, entity_type, token)
+            close_current()
+        elif boundary == "B":
+            close_current()
+            start_current(native_label, entity_type, token)
+        elif boundary == "I":
+            if current_label != native_label:
+                close_current()
+                start_current(native_label, entity_type, token)
+            else:
+                end = max(end, token.end)
+                scores.append(token.score)
+        elif boundary == "E":
+            if current_label != native_label:
+                close_current()
+                start_current(native_label, entity_type, token)
+            else:
+                end = max(end, token.end)
+                scores.append(token.score)
+            close_current()
+
+    close_current()
+    return spans
+
+
+def consolidate_candidates(candidates: Sequence[Candidate]) -> list[Candidate]:
+    # Exact duplicates occur in overlapping tokenizer windows. Keep the
+    # strongest instance, then join overlapping or touching fragments of the
+    # same model category before whitespace trimming and thresholding.
+    best: dict[tuple[str, int, int], Candidate] = {}
+    for candidate in candidates:
+        key = (candidate.native_label, candidate.start, candidate.end)
+        if key not in best or candidate.score > best[key].score:
+            best[key] = candidate
+
+    consolidated: list[Candidate] = []
+    for candidate in sorted(
+        best.values(),
+        key=lambda item: (item.native_label, item.start, -item.end, -item.score),
+    ):
+        previous = consolidated[-1] if consolidated else None
+        if (
+            previous is not None
+            and previous.native_label == candidate.native_label
+            and candidate.start <= previous.end
+        ):
+            extends_span = candidate.end > previous.end
+            consolidated[-1] = Candidate(
+                previous.native_label,
+                previous.entity_type,
+                previous.start,
+                max(previous.end, candidate.end),
+                max(previous.score, candidate.score) if extends_span else previous.score,
+            )
+        else:
+            consolidated.append(candidate)
+
+    consolidated.sort(key=lambda item: (item.start, item.end, item.entity_type))
+    return consolidated

--- a/detector/detector/openai_privacy_filter_decoder.py
+++ b/detector/detector/openai_privacy_filter_decoder.py
@@ -33,7 +33,6 @@ class TokenPrediction:
 
 @dataclass(frozen=True)
 class Candidate:
-    native_label: str
     entity_type: str
     start: int
     end: int
@@ -151,7 +150,7 @@ def viterbi_decode(
     return path
 
 
-def reconstruct_window(
+def reconstruct_spans(
     predictions: Sequence[TokenPrediction],
     text_length: int,
 ) -> list[Candidate]:
@@ -172,7 +171,6 @@ def reconstruct_window(
         ):
             spans.append(
                 Candidate(
-                    current_label,
                     current_type,
                     start,
                     end,
@@ -229,39 +227,3 @@ def reconstruct_window(
 
     close_current()
     return spans
-
-
-def consolidate_candidates(candidates: Sequence[Candidate]) -> list[Candidate]:
-    # Exact duplicates occur in overlapping tokenizer windows. Keep the
-    # strongest instance, then join overlapping or touching fragments of the
-    # same model category before whitespace trimming and thresholding.
-    best: dict[tuple[str, int, int], Candidate] = {}
-    for candidate in candidates:
-        key = (candidate.native_label, candidate.start, candidate.end)
-        if key not in best or candidate.score > best[key].score:
-            best[key] = candidate
-
-    consolidated: list[Candidate] = []
-    for candidate in sorted(
-        best.values(),
-        key=lambda item: (item.native_label, item.start, -item.end, -item.score),
-    ):
-        previous = consolidated[-1] if consolidated else None
-        if (
-            previous is not None
-            and previous.native_label == candidate.native_label
-            and candidate.start <= previous.end
-        ):
-            extends_span = candidate.end > previous.end
-            consolidated[-1] = Candidate(
-                previous.native_label,
-                previous.entity_type,
-                previous.start,
-                max(previous.end, candidate.end),
-                max(previous.score, candidate.score) if extends_span else previous.score,
-            )
-        else:
-            consolidated.append(candidate)
-
-    consolidated.sort(key=lambda item: (item.start, item.end, item.entity_type))
-    return consolidated

--- a/detector/detector/openai_privacy_filter_labels.py
+++ b/detector/detector/openai_privacy_filter_labels.py
@@ -1,0 +1,150 @@
+"""Label validation and canonical entity mapping for OpenAI Privacy Filter."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from .entities import (
+    ACCOUNT_NUMBER,
+    CREDIT_CARD,
+    DATE_TIME,
+    EMAIL_ADDRESS,
+    IBAN_CODE,
+    IP_ADDRESS,
+    LOCATION,
+    PERSON,
+    PHONE_NUMBER,
+    SECRET,
+    URL,
+    VAT_CODE,
+)
+
+BOUNDARY_RE = re.compile(r"^([BIES])-(.+)$")
+_LABEL_RE = re.compile(r"^([^-]+)-(.+)$")
+_SUPPORTED_BOUNDARIES = frozenset({"B", "I", "E", "S"})
+
+# The default checkpoint's eight native categories are required for
+# compatibility. Extra categories are allowed: recognized aliases are mapped
+# below and all other labels are intentionally ignored.
+REQUIRED_LABELS = frozenset(
+    {
+        "account_number",
+        "private_address",
+        "private_date",
+        "private_email",
+        "private_person",
+        "private_phone",
+        "private_url",
+        "secret",
+    }
+)
+
+LABEL_TO_TYPE = {
+    # Native OpenAI Privacy Filter labels.
+    "account_number": ACCOUNT_NUMBER,
+    "private_address": LOCATION,
+    "private_date": DATE_TIME,
+    "private_email": EMAIL_ADDRESS,
+    "private_person": PERSON,
+    "private_phone": PHONE_NUMBER,
+    "private_url": URL,
+    "secret": SECRET,
+    # Canonical aliases accepted from compatible fine-tunes. These are not
+    # emitted as distinct categories by the default checkpoint.
+    "person": PERSON,
+    "location": LOCATION,
+    "email_address": EMAIL_ADDRESS,
+    "phone_number": PHONE_NUMBER,
+    "credit_card": CREDIT_CARD,
+    "iban_code": IBAN_CODE,
+    "ip_address": IP_ADDRESS,
+    "url": URL,
+    "date_time": DATE_TIME,
+    "vat_code": VAT_CODE,
+}
+
+
+def label_state(raw_label: str) -> tuple[str | None, str | None]:
+    match = BOUNDARY_RE.fullmatch(raw_label)
+    if match is None:
+        return None, None
+    boundary, native_label = match.groups()
+    if native_label not in LABEL_TO_TYPE:
+        return None, None
+    return boundary, native_label
+
+
+def _normalized_id2label(raw: object) -> dict[int, str]:
+    if not isinstance(raw, Mapping):
+        return {}
+
+    labels: dict[int, str] = {}
+    for raw_id, raw_label in raw.items():
+        if isinstance(raw_id, bool) or not isinstance(raw_label, str):
+            continue
+        try:
+            label_id = int(raw_id)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if label_id < 0 or not raw_label:
+            continue
+        labels[label_id] = raw_label
+    return labels
+
+
+def validate_label_set(id2label: object, model_name: str) -> dict[int, str]:
+    """Validate and normalize a Privacy Filter-compatible label mapping."""
+
+    labels = _normalized_id2label(id2label)
+    raw_names = set(labels.values())
+    if "O" not in raw_names:
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
+            "checkpoint: its labels are missing O"
+        )
+
+    boundaries: dict[str, set[str]] = {}
+    for raw_label in raw_names:
+        match = _LABEL_RE.fullmatch(raw_label)
+        if match is None:
+            continue
+        boundary, native_label = match.groups()
+        boundaries.setdefault(native_label, set()).add(boundary)
+
+    unsupported_boundaries = sorted(
+        (label, tags - _SUPPORTED_BOUNDARIES)
+        for label, tags in boundaries.items()
+        if label in LABEL_TO_TYPE and tags - _SUPPORTED_BOUNDARIES
+    )
+    if unsupported_boundaries:
+        details = ", ".join(
+            f"{label}={','.join(sorted(tags))}" for label, tags in unsupported_boundaries
+        )
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
+            f"checkpoint: unsupported boundary prefixes ({details}); "
+            "expected BIO or BIOES labels"
+        )
+
+    missing = sorted(REQUIRED_LABELS - boundaries.keys())
+    if missing:
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
+            f"checkpoint: its labels are missing {', '.join(missing)}"
+        )
+
+    invalid_schemes = sorted(
+        label
+        for label in REQUIRED_LABELS
+        if boundaries[label] not in ({"B", "I"}, _SUPPORTED_BOUNDARIES)
+    )
+    if invalid_schemes:
+        details = ", ".join(
+            f"{label}={','.join(sorted(boundaries[label]))}" for label in invalid_schemes
+        )
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
+            f"checkpoint: incomplete BIO/BIOES boundaries ({details})"
+        )
+    return labels

--- a/detector/detector/openai_privacy_filter_layer.py
+++ b/detector/detector/openai_privacy_filter_layer.py
@@ -1,0 +1,742 @@
+"""OpenAI Privacy Filter semantic backend.
+
+The checkpoint emits token-level BIO or BIOES labels. This layer deliberately
+does not use Transformers' ``aggregation_strategy="simple"`` because that
+aggregator only understands B/I boundaries and treats E/S labels as generic
+continuations. Instead, it runs overlapping tokenizer windows and reconstructs
+complete spans from the checkpoint's labels while retaining exact tokenizer
+character offsets.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import threading
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from huggingface_hub import hf_hub_download
+from huggingface_hub.errors import (
+    HfHubHTTPError,
+    LocalEntryNotFoundError,
+    RemoteEntryNotFoundError,
+    RepositoryNotFoundError,
+)
+
+from .entities import (
+    ACCOUNT_NUMBER,
+    CREDIT_CARD,
+    DATE_TIME,
+    EMAIL_ADDRESS,
+    IBAN_CODE,
+    IP_ADDRESS,
+    LOCATION,
+    PERSON,
+    PHONE_NUMBER,
+    SECRET,
+    URL,
+    VAT_CODE,
+    Span,
+)
+
+DEFAULT_MODEL = "openai/privacy-filter"
+_MAX_STRIDE_TOKENS = 128
+_UNBOUNDED_MODEL_LENGTH = 1_000_000_000
+_BOUNDARY_RE = re.compile(r"^([BIES])-(.+)$")
+_LABEL_RE = re.compile(r"^([^-]+)-(.+)$")
+_SUPPORTED_BOUNDARIES = frozenset({"B", "I", "E", "S"})
+_VITERBI_CALIBRATION = "viterbi_calibration.json"
+_VITERBI_BIAS_KEYS = (
+    "transition_bias_background_stay",
+    "transition_bias_background_to_start",
+    "transition_bias_inside_to_continue",
+    "transition_bias_inside_to_end",
+    "transition_bias_end_to_background",
+    "transition_bias_end_to_start",
+)
+
+# The default checkpoint's eight native categories are required for
+# compatibility. Extra categories are allowed: recognized aliases are mapped
+# below and all other labels are intentionally ignored.
+_REQUIRED_LABELS = frozenset(
+    {
+        "account_number",
+        "private_address",
+        "private_date",
+        "private_email",
+        "private_person",
+        "private_phone",
+        "private_url",
+        "secret",
+    }
+)
+
+_LABEL_TO_TYPE = {
+    # Native OpenAI Privacy Filter labels.
+    "account_number": ACCOUNT_NUMBER,
+    "private_address": LOCATION,
+    "private_date": DATE_TIME,
+    "private_email": EMAIL_ADDRESS,
+    "private_person": PERSON,
+    "private_phone": PHONE_NUMBER,
+    "private_url": URL,
+    "secret": SECRET,
+    # Canonical aliases accepted from compatible fine-tunes. These are not
+    # emitted as distinct categories by the default checkpoint.
+    "person": PERSON,
+    "location": LOCATION,
+    "email_address": EMAIL_ADDRESS,
+    "phone_number": PHONE_NUMBER,
+    "credit_card": CREDIT_CARD,
+    "iban_code": IBAN_CODE,
+    "ip_address": IP_ADDRESS,
+    "url": URL,
+    "date_time": DATE_TIME,
+    "vat_code": VAT_CODE,
+}
+
+_tokenizer: Any = None
+_model: Any = None
+_id2label: dict[int, str] = {}
+_loaded_model_name: str | None = None
+_viterbi_biases: dict[str, float] = {key: 0.0 for key in _VITERBI_BIAS_KEYS}
+_load_lock = threading.Lock()
+# Torch inference is not guaranteed thread-safe.
+_infer_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _TokenPrediction:
+    label: str
+    start: int
+    end: int
+    score: float
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    native_label: str
+    entity_type: str
+    start: int
+    end: int
+    score: float
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
+
+
+def _normalized_id2label(raw: object) -> dict[int, str]:
+    if not isinstance(raw, Mapping):
+        return {}
+
+    labels: dict[int, str] = {}
+    for raw_id, raw_label in raw.items():
+        if isinstance(raw_id, bool) or not isinstance(raw_label, str):
+            continue
+        try:
+            label_id = int(raw_id)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if label_id < 0 or not raw_label:
+            continue
+        labels[label_id] = raw_label
+    return labels
+
+
+def validate_label_set(id2label: object, model_name: str) -> dict[int, str]:
+    """Validate and normalize a Privacy Filter-compatible label mapping.
+
+    Each required native category must provide either a complete BIO pair or a
+    complete BIOES quartet. Additional checkpoint labels are accepted so that
+    compatible fine-tunes can extend the taxonomy; unsupported additions are
+    ignored at inference.
+    """
+
+    labels = _normalized_id2label(id2label)
+    raw_names = set(labels.values())
+    if "O" not in raw_names:
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
+            "checkpoint: its labels are missing O"
+        )
+
+    boundaries: dict[str, set[str]] = {}
+    for raw_label in raw_names:
+        match = _LABEL_RE.fullmatch(raw_label)
+        if match is None:
+            continue
+        boundary, native_label = match.groups()
+        boundaries.setdefault(native_label, set()).add(boundary)
+
+    unsupported_boundaries = sorted(
+        (label, tags - _SUPPORTED_BOUNDARIES)
+        for label, tags in boundaries.items()
+        if label in _LABEL_TO_TYPE and tags - _SUPPORTED_BOUNDARIES
+    )
+    if unsupported_boundaries:
+        details = ", ".join(
+            f"{label}={','.join(sorted(tags))}" for label, tags in unsupported_boundaries
+        )
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
+            f"checkpoint: unsupported boundary prefixes ({details}); "
+            "expected BIO or BIOES labels"
+        )
+
+    missing = sorted(_REQUIRED_LABELS - boundaries.keys())
+    if missing:
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
+            f"checkpoint: its labels are missing {', '.join(missing)}"
+        )
+
+    invalid_schemes = sorted(
+        label
+        for label in _REQUIRED_LABELS
+        if boundaries[label] not in ({"B", "I"}, _SUPPORTED_BOUNDARIES)
+    )
+    if invalid_schemes:
+        details = ", ".join(
+            f"{label}={','.join(sorted(boundaries[label]))}" for label in invalid_schemes
+        )
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
+            f"checkpoint: incomplete BIO/BIOES boundaries ({details})"
+        )
+    return labels
+
+
+def _read_viterbi_biases(path: Path, model_name: str) -> dict[str, float]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        biases = payload["operating_points"]["default"]["biases"]
+    except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} has an invalid {_VITERBI_CALIBRATION}: {exc}"
+        ) from exc
+    if not isinstance(biases, Mapping) or set(biases) != set(_VITERBI_BIAS_KEYS):
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} has an invalid {_VITERBI_CALIBRATION}: "
+            f"biases must contain exactly {', '.join(_VITERBI_BIAS_KEYS)}"
+        )
+
+    normalized: dict[str, float] = {}
+    for key in _VITERBI_BIAS_KEYS:
+        value = biases[key]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"DETECTOR_MODEL {model_name!r} has an invalid {_VITERBI_CALIBRATION}: "
+                f"{key} must be numeric"
+            )
+        normalized[key] = float(value)
+        if not math.isfinite(normalized[key]):
+            raise ValueError(
+                f"DETECTOR_MODEL {model_name!r} has an invalid {_VITERBI_CALIBRATION}: "
+                f"{key} must be finite"
+            )
+    return normalized
+
+
+def _load_viterbi_biases(model_name: str) -> dict[str, float]:
+    default: dict[str, float] = {key: 0.0 for key in _VITERBI_BIAS_KEYS}
+    try:
+        model_path = Path(model_name).expanduser()
+    except RuntimeError:
+        model_path = Path(model_name)
+
+    if model_path.is_dir():
+        calibration_path = model_path / _VITERBI_CALIBRATION
+        if not calibration_path.is_file():
+            return default
+    else:
+        try:
+            calibration_path = Path(hf_hub_download(model_name, _VITERBI_CALIBRATION))
+        except (
+            HfHubHTTPError,
+            LocalEntryNotFoundError,
+            RemoteEntryNotFoundError,
+            RepositoryNotFoundError,
+        ):
+            return default
+    return _read_viterbi_biases(calibration_path, model_name)
+
+
+def _create_components(model_name: str) -> tuple[Any, Any, dict[str, float]]:
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
+    if not tokenizer.is_fast:
+        raise ValueError(
+            f"DETECTOR_MODEL {model_name!r} requires a fast tokenizer to preserve character offsets"
+        )
+    model = AutoModelForTokenClassification.from_pretrained(model_name)
+    model.eval()
+    return tokenizer, model, _load_viterbi_biases(model_name)
+
+
+def load_model(model_name: str = DEFAULT_MODEL) -> None:
+    """Load and validate one Privacy Filter checkpoint exactly once."""
+
+    global _id2label, _loaded_model_name, _model, _tokenizer, _viterbi_biases
+    if _model is not None:
+        if _loaded_model_name != model_name:
+            loaded = _loaded_model_name or "an unknown checkpoint"
+            raise RuntimeError(
+                f"OpenAI Privacy Filter is already loaded with {loaded!r}; "
+                f"cannot load {model_name!r}"
+            )
+        return
+
+    with _load_lock:
+        if _model is not None:
+            if _loaded_model_name != model_name:
+                loaded = _loaded_model_name or "an unknown checkpoint"
+                raise RuntimeError(
+                    f"OpenAI Privacy Filter is already loaded with {loaded!r}; "
+                    f"cannot load {model_name!r}"
+                )
+            return
+
+        tokenizer, model, viterbi_biases = _create_components(model_name)
+        labels = validate_label_set(
+            getattr(getattr(model, "config", None), "id2label", None),
+            model_name,
+        )
+        _tokenizer = tokenizer
+        _model = model
+        _id2label = labels
+        _viterbi_biases = viterbi_biases
+        _loaded_model_name = model_name
+
+
+def _model_max_tokens() -> int:
+    tokenizer_limit = getattr(_tokenizer, "model_max_length", None)
+    model_limit = getattr(getattr(_model, "config", None), "max_position_embeddings", None)
+    limits: list[int] = []
+    for raw_limit in (tokenizer_limit, model_limit):
+        if raw_limit is None or isinstance(raw_limit, bool):
+            continue
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if 1 < limit < _UNBOUNDED_MODEL_LENGTH:
+            limits.append(limit)
+    if not limits:
+        raise ValueError("OpenAI Privacy Filter tokenizer has no finite model_max_length")
+    return min(limits)
+
+
+def _inference_stride(max_tokens: int) -> int:
+    try:
+        special_tokens = int(_tokenizer.num_special_tokens_to_add(pair=False))
+    except (AttributeError, TypeError, ValueError, OverflowError):
+        special_tokens = 0
+    content_tokens = max_tokens - max(0, special_tokens)
+    if content_tokens < 2:
+        raise ValueError(
+            "OpenAI Privacy Filter tokenizer model_max_length is too small for inference"
+        )
+    return min(_MAX_STRIDE_TOKENS, max(1, content_tokens // 4))
+
+
+def _as_windows(value: object) -> list[list[Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    items = list(value)
+    if not items:
+        return []
+    first = items[0]
+    if isinstance(first, Sequence) and not isinstance(first, (str, bytes)):
+        return [list(item) for item in items if isinstance(item, Sequence)]
+    return [items]
+
+
+def _finite_score(value: object) -> float | None:
+    try:
+        score = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(score):
+        return None
+    return min(1.0, max(0.0, score))
+
+
+def _offset_pair(value: object) -> tuple[int, int] | None:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or len(value) != 2:
+        return None
+    raw_start, raw_end = value
+    if isinstance(raw_start, bool) or isinstance(raw_end, bool):
+        return None
+    try:
+        start = int(raw_start)
+        end = int(raw_end)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if raw_start != start or raw_end != end:
+        return None
+    return start, end
+
+
+def _label_state(raw_label: str) -> tuple[str | None, str | None]:
+    match = _BOUNDARY_RE.fullmatch(raw_label)
+    if match is None:
+        return None, None
+    boundary, native_label = match.groups()
+    if native_label not in _LABEL_TO_TYPE:
+        return None, None
+    return boundary, native_label
+
+
+def _transition_bias(
+    previous: tuple[str | None, str | None],
+    following: tuple[str | None, str | None],
+    boundaries: Mapping[str, set[str]],
+) -> float | None:
+    previous_boundary, previous_label = previous
+    following_boundary, following_label = following
+    previous_is_background = previous_label is None
+    following_is_background = following_label is None
+
+    if previous_is_background:
+        if following_is_background:
+            return _viterbi_biases["transition_bias_background_stay"]
+        if following_boundary in {"B", "S"}:
+            return _viterbi_biases["transition_bias_background_to_start"]
+        return None
+
+    previous_is_bio = boundaries.get(previous_label) == {"B", "I"}
+    if previous_is_bio:
+        if following_label == previous_label and following_boundary == "I":
+            return _viterbi_biases["transition_bias_inside_to_continue"]
+        if following_is_background:
+            return _viterbi_biases["transition_bias_end_to_background"]
+        if following_boundary in {"B", "S"}:
+            return _viterbi_biases["transition_bias_end_to_start"]
+        return None
+
+    if previous_boundary in {"B", "I"}:
+        if following_label != previous_label:
+            return None
+        if following_boundary == "I":
+            return _viterbi_biases["transition_bias_inside_to_continue"]
+        if following_boundary == "E":
+            return _viterbi_biases["transition_bias_inside_to_end"]
+        return None
+
+    if previous_boundary in {"E", "S"}:
+        if following_is_background:
+            return _viterbi_biases["transition_bias_end_to_background"]
+        if following_boundary in {"B", "S"}:
+            return _viterbi_biases["transition_bias_end_to_start"]
+    return None
+
+
+def _viterbi_decode(log_probabilities: Any) -> list[int]:
+    """Return the highest-scoring structurally valid BIO/BIOES label path."""
+
+    import torch
+
+    if log_probabilities.ndim != 2:
+        raise ValueError("OpenAI Privacy Filter logits must have shape [tokens, labels]")
+    sequence_length, class_count = log_probabilities.shape
+    if sequence_length == 0:
+        return []
+
+    states = [_label_state(_id2label.get(index, "O")) for index in range(class_count)]
+    boundaries: dict[str, set[str]] = {}
+    for boundary, native_label in states:
+        if boundary is not None and native_label is not None:
+            boundaries.setdefault(native_label, set()).add(boundary)
+
+    negative_infinity = -1e9
+    start_scores = torch.full_like(log_probabilities[0], negative_infinity)
+    end_scores = torch.full_like(log_probabilities[0], negative_infinity)
+    transition_scores = torch.full(
+        (class_count, class_count),
+        negative_infinity,
+        device=log_probabilities.device,
+        dtype=log_probabilities.dtype,
+    )
+
+    for index, (boundary, native_label) in enumerate(states):
+        is_background = native_label is None
+        is_bio = native_label is not None and boundaries.get(native_label) == {"B", "I"}
+        if is_background or boundary in {"B", "S"}:
+            start_scores[index] = 0.0
+        if is_background or boundary in {"E", "S"} or (is_bio and boundary in {"B", "I"}):
+            end_scores[index] = 0.0
+        for following_index, following in enumerate(states):
+            bias = _transition_bias((boundary, native_label), following, boundaries)
+            if bias is not None:
+                transition_scores[index, following_index] = bias
+
+    scores = log_probabilities[0] + start_scores
+    backpointers = []
+    for token_index in range(1, sequence_length):
+        paths = scores.unsqueeze(1) + transition_scores
+        best_scores, best_previous = paths.max(dim=0)
+        scores = best_scores + log_probabilities[token_index]
+        backpointers.append(best_previous)
+
+    scores = scores + end_scores
+    last_label = int(scores.argmax())
+    path = [last_label]
+    for previous in reversed(backpointers):
+        last_label = int(previous[last_label])
+        path.append(last_label)
+    path.reverse()
+    return path
+
+
+def _predict_windows(text: str) -> list[list[_TokenPrediction]]:
+    import torch
+
+    max_tokens = _model_max_tokens()
+    stride = _inference_stride(max_tokens)
+    encoded = _tokenizer(
+        text,
+        truncation=True,
+        max_length=max_tokens,
+        stride=stride,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        return_special_tokens_mask=True,
+        padding=False,
+    )
+
+    input_windows = _as_windows(encoded.get("input_ids"))
+    attention_windows = _as_windows(encoded.get("attention_mask"))
+    offset_windows = _as_windows(encoded.get("offset_mapping"))
+    special_windows = _as_windows(encoded.get("special_tokens_mask"))
+    if not input_windows or len(offset_windows) != len(input_windows):
+        raise RuntimeError("OpenAI Privacy Filter tokenizer did not return character offsets")
+
+    try:
+        device = next(_model.parameters()).device
+    except (AttributeError, StopIteration, TypeError):
+        device = None
+
+    predictions: list[list[_TokenPrediction]] = []
+    for window_index, input_ids in enumerate(input_windows):
+        attention = (
+            attention_windows[window_index]
+            if window_index < len(attention_windows)
+            else [1] * len(input_ids)
+        )
+        offsets = offset_windows[window_index]
+        special = (
+            special_windows[window_index]
+            if window_index < len(special_windows)
+            else [0] * len(input_ids)
+        )
+        tensor_kwargs = {"device": device} if device is not None else {}
+        model_inputs = {
+            "input_ids": torch.tensor([input_ids], **tensor_kwargs),
+            "attention_mask": torch.tensor([attention], **tensor_kwargs),
+        }
+        with torch.inference_mode():
+            output = _model(**model_inputs)
+            logits = output["logits"] if isinstance(output, Mapping) else output.logits
+
+        window_predictions: list[_TokenPrediction] = []
+        token_count = min(
+            len(input_ids),
+            len(attention),
+            len(offsets),
+            len(special),
+            len(logits[0]),
+        )
+        active_tokens: list[tuple[int, int, int]] = []
+        for token_index in range(token_count):
+            if not bool(attention[token_index]) or bool(special[token_index]):
+                continue
+            offset = _offset_pair(offsets[token_index])
+            if offset is None:
+                continue
+            start, end = offset
+            if not 0 <= start < end <= len(text):
+                continue
+            active_tokens.append((token_index, start, end))
+
+        if not active_tokens:
+            predictions.append([])
+            continue
+
+        log_probabilities = logits[0].float().log_softmax(dim=-1)
+        active_log_probabilities = log_probabilities[
+            [token_index for token_index, _, _ in active_tokens]
+        ]
+        label_ids = _viterbi_decode(active_log_probabilities)
+        probabilities = active_log_probabilities.exp()
+        for prediction_index, ((_, start, end), label_id) in enumerate(
+            zip(active_tokens, label_ids, strict=True)
+        ):
+            label = _id2label.get(label_id)
+            score = _finite_score(probabilities[prediction_index, label_id])
+            if label is None or score is None:
+                continue
+            window_predictions.append(_TokenPrediction(label, start, end, score))
+        predictions.append(window_predictions)
+    return predictions
+
+
+def _reconstruct_window(
+    predictions: Sequence[_TokenPrediction],
+    text_length: int,
+) -> list[_Candidate]:
+    spans: list[_Candidate] = []
+    current_label: str | None = None
+    current_type: str | None = None
+    start = 0
+    end = 0
+    scores: list[float] = []
+
+    def close_current() -> None:
+        nonlocal current_label, current_type, end, scores, start
+        if (
+            current_label is not None
+            and current_type is not None
+            and scores
+            and 0 <= start < end <= text_length
+        ):
+            spans.append(
+                _Candidate(
+                    current_label,
+                    current_type,
+                    start,
+                    end,
+                    sum(scores) / len(scores),
+                )
+            )
+        current_label = None
+        current_type = None
+        start = 0
+        end = 0
+        scores = []
+
+    def start_current(native_label: str, entity_type: str, token: _TokenPrediction) -> None:
+        nonlocal current_label, current_type, end, scores, start
+        current_label = native_label
+        current_type = entity_type
+        start = token.start
+        end = token.end
+        scores = [token.score]
+
+    for token in predictions:
+        match = _BOUNDARY_RE.fullmatch(token.label)
+        if match is None:
+            close_current()
+            continue
+        boundary, native_label = match.groups()
+        entity_type = _LABEL_TO_TYPE.get(native_label)
+        if entity_type is None:
+            # Compatible fine-tunes may add categories that PasteGuard does not
+            # expose. Treat them as background rather than inventing a type.
+            close_current()
+            continue
+
+        if boundary == "S":
+            close_current()
+            start_current(native_label, entity_type, token)
+            close_current()
+        elif boundary == "B":
+            close_current()
+            start_current(native_label, entity_type, token)
+        elif boundary == "I":
+            if current_label != native_label:
+                close_current()
+                start_current(native_label, entity_type, token)
+            else:
+                end = max(end, token.end)
+                scores.append(token.score)
+        elif boundary == "E":
+            if current_label != native_label:
+                close_current()
+                start_current(native_label, entity_type, token)
+            else:
+                end = max(end, token.end)
+                scores.append(token.score)
+            close_current()
+
+    close_current()
+    return spans
+
+
+def _consolidate_candidates(candidates: Sequence[_Candidate]) -> list[_Candidate]:
+    # Exact duplicates occur in overlapping tokenizer windows. Keep the
+    # strongest instance, then join overlapping or touching fragments of the
+    # same model category before whitespace trimming and thresholding.
+    best: dict[tuple[str, int, int], _Candidate] = {}
+    for candidate in candidates:
+        key = (candidate.native_label, candidate.start, candidate.end)
+        if key not in best or candidate.score > best[key].score:
+            best[key] = candidate
+
+    consolidated: list[_Candidate] = []
+    for candidate in sorted(
+        best.values(),
+        key=lambda item: (item.native_label, item.start, -item.end, -item.score),
+    ):
+        previous = consolidated[-1] if consolidated else None
+        if (
+            previous is not None
+            and previous.native_label == candidate.native_label
+            and candidate.start <= previous.end
+        ):
+            extends_span = candidate.end > previous.end
+            consolidated[-1] = _Candidate(
+                previous.native_label,
+                previous.entity_type,
+                previous.start,
+                max(previous.end, candidate.end),
+                max(previous.score, candidate.score) if extends_span else previous.score,
+            )
+        else:
+            consolidated.append(candidate)
+
+    consolidated.sort(key=lambda item: (item.start, item.end, item.entity_type))
+    return consolidated
+
+
+def detect_openai_privacy_filter(text: str, score_threshold: float = 0.0) -> list[Span]:
+    if not text:
+        return []
+    if _model is None or _tokenizer is None:
+        raise RuntimeError(
+            "OpenAI Privacy Filter model not loaded; load_semantic_backend() selects and loads it"
+        )
+
+    with _infer_lock:
+        windows = _predict_windows(text)
+
+    candidates = _consolidate_candidates(
+        [
+            candidate
+            for predictions in windows
+            for candidate in _reconstruct_window(predictions, len(text))
+        ]
+    )
+
+    spans: list[Span] = []
+    for candidate in candidates:
+        start, end = candidate.start, candidate.end
+        while start < end and text[start].isspace():
+            start += 1
+        while start < end and text[end - 1].isspace():
+            end -= 1
+        if start < end and candidate.score >= score_threshold:
+            spans.append(
+                Span(
+                    candidate.entity_type,
+                    start,
+                    end,
+                    candidate.score,
+                )
+            )
+    return spans

--- a/detector/detector/openai_privacy_filter_layer.py
+++ b/detector/detector/openai_privacy_filter_layer.py
@@ -45,6 +45,7 @@ _id2label: dict[int, str] = {}
 _loaded_model_name: str | None = None
 _viterbi_biases = default_viterbi_biases()
 _inference_max_tokens = _DEFAULT_MAX_TOKENS
+_inference_stride_tokens = _WINDOW_OVERLAP_TOKENS
 _candidate_cache: OrderedDict[tuple[int, bytes], tuple[Candidate, ...]] = OrderedDict()
 _load_lock = threading.Lock()
 # Torch inference is not guaranteed thread-safe.
@@ -141,8 +142,8 @@ def _configured_max_tokens() -> int:
 def load_model(model_name: str = DEFAULT_MODEL) -> None:
     """Load and validate one Privacy Filter checkpoint exactly once."""
 
-    global _id2label, _inference_max_tokens, _loaded_model_name, _model, _tokenizer
-    global _viterbi_biases
+    global _id2label, _inference_max_tokens, _inference_stride_tokens
+    global _loaded_model_name, _model, _tokenizer, _viterbi_biases
     if _model is not None:
         if _loaded_model_name != model_name:
             loaded = _loaded_model_name or "an unknown checkpoint"
@@ -162,24 +163,31 @@ def load_model(model_name: str = DEFAULT_MODEL) -> None:
                 )
             return
 
-        inference_max_tokens = _configured_max_tokens()
+        configured_max_tokens = _configured_max_tokens()
         tokenizer, model, viterbi_biases = _create_components(model_name)
         labels = validate_label_set(
             getattr(getattr(model, "config", None), "id2label", None),
             model_name,
         )
+        inference_max_tokens = _model_max_tokens(
+            tokenizer,
+            model,
+            configured_max_tokens,
+        )
+        inference_stride_tokens = _inference_stride(tokenizer, inference_max_tokens)
         _tokenizer = tokenizer
         _model = model
         _id2label = labels
         _viterbi_biases = viterbi_biases
         _inference_max_tokens = inference_max_tokens
+        _inference_stride_tokens = inference_stride_tokens
         _loaded_model_name = model_name
         _candidate_cache.clear()
 
 
-def _model_max_tokens() -> int:
-    tokenizer_limit = getattr(_tokenizer, "model_max_length", None)
-    model_limit = getattr(getattr(_model, "config", None), "max_position_embeddings", None)
+def _model_max_tokens(tokenizer: Any, model: Any, configured_max_tokens: int) -> int:
+    tokenizer_limit = getattr(tokenizer, "model_max_length", None)
+    model_limit = getattr(getattr(model, "config", None), "max_position_embeddings", None)
     limits: list[int] = []
     for raw_limit in (tokenizer_limit, model_limit):
         if raw_limit is None or isinstance(raw_limit, bool):
@@ -192,12 +200,12 @@ def _model_max_tokens() -> int:
             limits.append(limit)
     if not limits:
         raise ValueError("OpenAI Privacy Filter tokenizer has no finite model_max_length")
-    return min(_inference_max_tokens, *limits)
+    return min(configured_max_tokens, *limits)
 
 
-def _inference_stride(max_tokens: int) -> int:
+def _inference_stride(tokenizer: Any, max_tokens: int) -> int:
     try:
-        special_tokens = int(_tokenizer.num_special_tokens_to_add(pair=False))
+        special_tokens = int(tokenizer.num_special_tokens_to_add(pair=False))
     except (AttributeError, TypeError, ValueError, OverflowError):
         special_tokens = 0
     content_tokens = max_tokens - max(0, special_tokens)
@@ -249,13 +257,11 @@ def _offset_pair(value: object) -> tuple[int, int] | None:
 def _predict_tokens(text: str) -> list[TokenPrediction]:
     import torch
 
-    max_tokens = _model_max_tokens()
-    stride = _inference_stride(max_tokens)
     encoded = _tokenizer(
         text,
         truncation=True,
-        max_length=max_tokens,
-        stride=stride,
+        max_length=_inference_max_tokens,
+        stride=_inference_stride_tokens,
         return_overflowing_tokens=True,
         return_offsets_mapping=True,
         return_special_tokens_mask=True,
@@ -281,7 +287,7 @@ def _predict_tokens(text: str) -> list[TokenPrediction]:
     previous_content_tokens = 0
     for window_index, input_ids in enumerate(input_windows):
         if window_index:
-            step = previous_content_tokens - stride
+            step = previous_content_tokens - _inference_stride_tokens
             if step <= 0:
                 raise RuntimeError(
                     "OpenAI Privacy Filter tokenizer returned invalid overlap windows"

--- a/detector/detector/openai_privacy_filter_layer.py
+++ b/detector/detector/openai_privacy_filter_layer.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import threading
+from collections import OrderedDict
 from collections.abc import Mapping, Sequence
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
@@ -20,16 +23,19 @@ from huggingface_hub.errors import (
 from .entities import Span
 from .openai_privacy_filter_decoder import (
     VITERBI_BIAS_KEYS,
+    Candidate,
     TokenPrediction,
-    consolidate_candidates,
     default_viterbi_biases,
-    reconstruct_window,
+    reconstruct_spans,
     viterbi_decode,
 )
 from .openai_privacy_filter_labels import validate_label_set
 
 DEFAULT_MODEL = "openai/privacy-filter"
-_MAX_STRIDE_TOKENS = 128
+_DEFAULT_MAX_TOKENS = 2048
+_MIN_MAX_TOKENS = 256
+_WINDOW_OVERLAP_TOKENS = 128
+_CANDIDATE_CACHE_SIZE = 1024
 _UNBOUNDED_MODEL_LENGTH = 1_000_000_000
 _VITERBI_CALIBRATION = "viterbi_calibration.json"
 
@@ -38,6 +44,8 @@ _model: Any = None
 _id2label: dict[int, str] = {}
 _loaded_model_name: str | None = None
 _viterbi_biases = default_viterbi_biases()
+_inference_max_tokens = _DEFAULT_MAX_TOKENS
+_candidate_cache: OrderedDict[tuple[int, bytes], tuple[Candidate, ...]] = OrderedDict()
 _load_lock = threading.Lock()
 # Torch inference is not guaranteed thread-safe.
 _infer_lock = threading.Lock()
@@ -111,10 +119,30 @@ def _create_components(model_name: str) -> tuple[Any, Any, dict[str, float]]:
     return tokenizer, model, _load_viterbi_biases(model_name)
 
 
+def _configured_max_tokens() -> int:
+    value = os.environ.get("OPENAI_PRIVACY_FILTER_MAX_TOKENS")
+    if value is None:
+        return _DEFAULT_MAX_TOKENS
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise ValueError(
+            "OPENAI_PRIVACY_FILTER_MAX_TOKENS must be an integer of at least "
+            f"{_MIN_MAX_TOKENS}; got {value!r}"
+        ) from None
+    if parsed < _MIN_MAX_TOKENS:
+        raise ValueError(
+            "OPENAI_PRIVACY_FILTER_MAX_TOKENS must be an integer of at least "
+            f"{_MIN_MAX_TOKENS}; got {value!r}"
+        )
+    return parsed
+
+
 def load_model(model_name: str = DEFAULT_MODEL) -> None:
     """Load and validate one Privacy Filter checkpoint exactly once."""
 
-    global _id2label, _loaded_model_name, _model, _tokenizer, _viterbi_biases
+    global _id2label, _inference_max_tokens, _loaded_model_name, _model, _tokenizer
+    global _viterbi_biases
     if _model is not None:
         if _loaded_model_name != model_name:
             loaded = _loaded_model_name or "an unknown checkpoint"
@@ -134,6 +162,7 @@ def load_model(model_name: str = DEFAULT_MODEL) -> None:
                 )
             return
 
+        inference_max_tokens = _configured_max_tokens()
         tokenizer, model, viterbi_biases = _create_components(model_name)
         labels = validate_label_set(
             getattr(getattr(model, "config", None), "id2label", None),
@@ -143,7 +172,9 @@ def load_model(model_name: str = DEFAULT_MODEL) -> None:
         _model = model
         _id2label = labels
         _viterbi_biases = viterbi_biases
+        _inference_max_tokens = inference_max_tokens
         _loaded_model_name = model_name
+        _candidate_cache.clear()
 
 
 def _model_max_tokens() -> int:
@@ -161,7 +192,7 @@ def _model_max_tokens() -> int:
             limits.append(limit)
     if not limits:
         raise ValueError("OpenAI Privacy Filter tokenizer has no finite model_max_length")
-    return min(limits)
+    return min(_inference_max_tokens, *limits)
 
 
 def _inference_stride(max_tokens: int) -> int:
@@ -174,7 +205,7 @@ def _inference_stride(max_tokens: int) -> int:
         raise ValueError(
             "OpenAI Privacy Filter tokenizer model_max_length is too small for inference"
         )
-    return min(_MAX_STRIDE_TOKENS, max(1, content_tokens // 4))
+    return min(_WINDOW_OVERLAP_TOKENS, max(1, content_tokens // 4))
 
 
 def _as_windows(value: object) -> list[list[Any]]:
@@ -215,7 +246,7 @@ def _offset_pair(value: object) -> tuple[int, int] | None:
     return start, end
 
 
-def _predict_windows(text: str) -> list[list[TokenPrediction]]:
+def _predict_tokens(text: str) -> list[TokenPrediction]:
     import torch
 
     max_tokens = _model_max_tokens()
@@ -243,8 +274,20 @@ def _predict_windows(text: str) -> list[list[TokenPrediction]]:
     except (AttributeError, StopIteration, TypeError):
         device = None
 
-    predictions: list[list[TokenPrediction]] = []
+    token_metadata: dict[int, tuple[int, int, int]] = {}
+    score_sums: dict[int, Any] = {}
+    score_counts: dict[int, int] = {}
+    window_start = 0
+    previous_content_tokens = 0
     for window_index, input_ids in enumerate(input_windows):
+        if window_index:
+            step = previous_content_tokens - stride
+            if step <= 0:
+                raise RuntimeError(
+                    "OpenAI Privacy Filter tokenizer returned invalid overlap windows"
+                )
+            window_start += step
+
         attention = (
             attention_windows[window_index]
             if window_index < len(attention_windows)
@@ -272,37 +315,84 @@ def _predict_windows(text: str) -> list[list[TokenPrediction]]:
             len(special),
             len(logits[0]),
         )
-        active_tokens: list[tuple[int, int, int]] = []
+        active_tokens: list[tuple[int, int, int, int, int]] = []
+        content_position = 0
         for token_index in range(token_count):
             if not bool(attention[token_index]) or bool(special[token_index]):
                 continue
+            absolute_position = window_start + content_position
+            content_position += 1
             offset = _offset_pair(offsets[token_index])
             if offset is None:
                 continue
             start, end = offset
             if 0 <= start < end <= len(text):
-                active_tokens.append((token_index, start, end))
-
-        if not active_tokens:
-            predictions.append([])
-            continue
+                active_tokens.append(
+                    (
+                        absolute_position,
+                        int(input_ids[token_index]),
+                        token_index,
+                        start,
+                        end,
+                    )
+                )
+        previous_content_tokens = content_position
 
         log_probabilities = logits[0].float().log_softmax(dim=-1)
-        active_log_probabilities = log_probabilities[
-            [token_index for token_index, _, _ in active_tokens]
-        ]
-        label_ids = viterbi_decode(active_log_probabilities, _id2label, _viterbi_biases)
-        probabilities = active_log_probabilities.exp()
-        window_predictions: list[TokenPrediction] = []
-        for prediction_index, ((_, start, end), label_id) in enumerate(
-            zip(active_tokens, label_ids, strict=True)
-        ):
-            label = _id2label.get(label_id)
-            score = _finite_score(probabilities[prediction_index, label_id])
-            if label is not None and score is not None:
-                window_predictions.append(TokenPrediction(label, start, end, score))
-        predictions.append(window_predictions)
+        for absolute_position, token_id, token_index, start, end in active_tokens:
+            scores = log_probabilities[token_index]
+            metadata = (token_id, start, end)
+            previous_metadata = token_metadata.get(absolute_position)
+            if previous_metadata is None:
+                token_metadata[absolute_position] = metadata
+                score_sums[absolute_position] = scores
+                score_counts[absolute_position] = 1
+            elif previous_metadata != metadata:
+                raise RuntimeError(
+                    "OpenAI Privacy Filter tokenizer returned inconsistent overlap offsets"
+                )
+            else:
+                score_sums[absolute_position] = torch.logaddexp(
+                    score_sums[absolute_position], scores
+                )
+                score_counts[absolute_position] += 1
+
+    if not score_sums:
+        return []
+
+    positions = sorted(score_sums)
+    averaged_log_probabilities = torch.stack(
+        [score_sums[position] - math.log(float(score_counts[position])) for position in positions]
+    )
+    label_ids = viterbi_decode(averaged_log_probabilities, _id2label, _viterbi_biases)
+    probabilities = averaged_log_probabilities.exp()
+
+    predictions: list[TokenPrediction] = []
+    for prediction_index, (position, label_id) in enumerate(zip(positions, label_ids, strict=True)):
+        label = _id2label.get(label_id)
+        score = _finite_score(probabilities[prediction_index, label_id])
+        if label is not None and score is not None:
+            _, start, end = token_metadata[position]
+            predictions.append(TokenPrediction(label, start, end, score))
     return predictions
+
+
+def _candidate_cache_key(text: str) -> tuple[int, bytes]:
+    return len(text), sha256(text.encode("utf-8")).digest()
+
+
+def _candidates_for_text(text: str) -> tuple[Candidate, ...]:
+    key = _candidate_cache_key(text)
+    cached = _candidate_cache.get(key)
+    if cached is not None:
+        _candidate_cache.move_to_end(key)
+        return cached
+
+    candidates = tuple(reconstruct_spans(_predict_tokens(text), len(text)))
+    _candidate_cache[key] = candidates
+    if len(_candidate_cache) > _CANDIDATE_CACHE_SIZE:
+        _candidate_cache.popitem(last=False)
+    return candidates
 
 
 def detect_openai_privacy_filter(text: str, score_threshold: float = 0.0) -> list[Span]:
@@ -314,15 +404,7 @@ def detect_openai_privacy_filter(text: str, score_threshold: float = 0.0) -> lis
         )
 
     with _infer_lock:
-        windows = _predict_windows(text)
-
-    candidates = consolidate_candidates(
-        [
-            candidate
-            for predictions in windows
-            for candidate in reconstruct_window(predictions, len(text))
-        ]
-    )
+        candidates = _candidates_for_text(text)
 
     spans: list[Span] = []
     for candidate in candidates:

--- a/detector/detector/openai_privacy_filter_layer.py
+++ b/detector/detector/openai_privacy_filter_layer.py
@@ -1,21 +1,11 @@
-"""OpenAI Privacy Filter semantic backend.
-
-The checkpoint emits token-level BIO or BIOES labels. This layer deliberately
-does not use Transformers' ``aggregation_strategy="simple"`` because that
-aggregator only understands B/I boundaries and treats E/S labels as generic
-continuations. Instead, it runs overlapping tokenizer windows and reconstructs
-complete spans from the checkpoint's labels while retaining exact tokenizer
-character offsets.
-"""
+"""Model loading and inference for the OpenAI Privacy Filter backend."""
 
 from __future__ import annotations
 
 import json
 import math
-import re
 import threading
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -27,188 +17,30 @@ from huggingface_hub.errors import (
     RepositoryNotFoundError,
 )
 
-from .entities import (
-    ACCOUNT_NUMBER,
-    CREDIT_CARD,
-    DATE_TIME,
-    EMAIL_ADDRESS,
-    IBAN_CODE,
-    IP_ADDRESS,
-    LOCATION,
-    PERSON,
-    PHONE_NUMBER,
-    SECRET,
-    URL,
-    VAT_CODE,
-    Span,
+from .entities import Span
+from .openai_privacy_filter_decoder import (
+    VITERBI_BIAS_KEYS,
+    TokenPrediction,
+    consolidate_candidates,
+    default_viterbi_biases,
+    reconstruct_window,
+    viterbi_decode,
 )
+from .openai_privacy_filter_labels import validate_label_set
 
 DEFAULT_MODEL = "openai/privacy-filter"
 _MAX_STRIDE_TOKENS = 128
 _UNBOUNDED_MODEL_LENGTH = 1_000_000_000
-_BOUNDARY_RE = re.compile(r"^([BIES])-(.+)$")
-_LABEL_RE = re.compile(r"^([^-]+)-(.+)$")
-_SUPPORTED_BOUNDARIES = frozenset({"B", "I", "E", "S"})
 _VITERBI_CALIBRATION = "viterbi_calibration.json"
-_VITERBI_BIAS_KEYS = (
-    "transition_bias_background_stay",
-    "transition_bias_background_to_start",
-    "transition_bias_inside_to_continue",
-    "transition_bias_inside_to_end",
-    "transition_bias_end_to_background",
-    "transition_bias_end_to_start",
-)
-
-# The default checkpoint's eight native categories are required for
-# compatibility. Extra categories are allowed: recognized aliases are mapped
-# below and all other labels are intentionally ignored.
-_REQUIRED_LABELS = frozenset(
-    {
-        "account_number",
-        "private_address",
-        "private_date",
-        "private_email",
-        "private_person",
-        "private_phone",
-        "private_url",
-        "secret",
-    }
-)
-
-_LABEL_TO_TYPE = {
-    # Native OpenAI Privacy Filter labels.
-    "account_number": ACCOUNT_NUMBER,
-    "private_address": LOCATION,
-    "private_date": DATE_TIME,
-    "private_email": EMAIL_ADDRESS,
-    "private_person": PERSON,
-    "private_phone": PHONE_NUMBER,
-    "private_url": URL,
-    "secret": SECRET,
-    # Canonical aliases accepted from compatible fine-tunes. These are not
-    # emitted as distinct categories by the default checkpoint.
-    "person": PERSON,
-    "location": LOCATION,
-    "email_address": EMAIL_ADDRESS,
-    "phone_number": PHONE_NUMBER,
-    "credit_card": CREDIT_CARD,
-    "iban_code": IBAN_CODE,
-    "ip_address": IP_ADDRESS,
-    "url": URL,
-    "date_time": DATE_TIME,
-    "vat_code": VAT_CODE,
-}
 
 _tokenizer: Any = None
 _model: Any = None
 _id2label: dict[int, str] = {}
 _loaded_model_name: str | None = None
-_viterbi_biases: dict[str, float] = {key: 0.0 for key in _VITERBI_BIAS_KEYS}
+_viterbi_biases = default_viterbi_biases()
 _load_lock = threading.Lock()
 # Torch inference is not guaranteed thread-safe.
 _infer_lock = threading.Lock()
-
-
-@dataclass(frozen=True)
-class _TokenPrediction:
-    label: str
-    start: int
-    end: int
-    score: float
-
-
-@dataclass(frozen=True)
-class _Candidate:
-    native_label: str
-    entity_type: str
-    start: int
-    end: int
-    score: float
-
-    @property
-    def length(self) -> int:
-        return self.end - self.start
-
-
-def _normalized_id2label(raw: object) -> dict[int, str]:
-    if not isinstance(raw, Mapping):
-        return {}
-
-    labels: dict[int, str] = {}
-    for raw_id, raw_label in raw.items():
-        if isinstance(raw_id, bool) or not isinstance(raw_label, str):
-            continue
-        try:
-            label_id = int(raw_id)
-        except (TypeError, ValueError, OverflowError):
-            continue
-        if label_id < 0 or not raw_label:
-            continue
-        labels[label_id] = raw_label
-    return labels
-
-
-def validate_label_set(id2label: object, model_name: str) -> dict[int, str]:
-    """Validate and normalize a Privacy Filter-compatible label mapping.
-
-    Each required native category must provide either a complete BIO pair or a
-    complete BIOES quartet. Additional checkpoint labels are accepted so that
-    compatible fine-tunes can extend the taxonomy; unsupported additions are
-    ignored at inference.
-    """
-
-    labels = _normalized_id2label(id2label)
-    raw_names = set(labels.values())
-    if "O" not in raw_names:
-        raise ValueError(
-            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
-            "checkpoint: its labels are missing O"
-        )
-
-    boundaries: dict[str, set[str]] = {}
-    for raw_label in raw_names:
-        match = _LABEL_RE.fullmatch(raw_label)
-        if match is None:
-            continue
-        boundary, native_label = match.groups()
-        boundaries.setdefault(native_label, set()).add(boundary)
-
-    unsupported_boundaries = sorted(
-        (label, tags - _SUPPORTED_BOUNDARIES)
-        for label, tags in boundaries.items()
-        if label in _LABEL_TO_TYPE and tags - _SUPPORTED_BOUNDARIES
-    )
-    if unsupported_boundaries:
-        details = ", ".join(
-            f"{label}={','.join(sorted(tags))}" for label, tags in unsupported_boundaries
-        )
-        raise ValueError(
-            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
-            f"checkpoint: unsupported boundary prefixes ({details}); "
-            "expected BIO or BIOES labels"
-        )
-
-    missing = sorted(_REQUIRED_LABELS - boundaries.keys())
-    if missing:
-        raise ValueError(
-            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
-            f"checkpoint: its labels are missing {', '.join(missing)}"
-        )
-
-    invalid_schemes = sorted(
-        label
-        for label in _REQUIRED_LABELS
-        if boundaries[label] not in ({"B", "I"}, _SUPPORTED_BOUNDARIES)
-    )
-    if invalid_schemes:
-        details = ", ".join(
-            f"{label}={','.join(sorted(boundaries[label]))}" for label in invalid_schemes
-        )
-        raise ValueError(
-            f"DETECTOR_MODEL {model_name!r} is not a Privacy Filter-compatible "
-            f"checkpoint: incomplete BIO/BIOES boundaries ({details})"
-        )
-    return labels
 
 
 def _read_viterbi_biases(path: Path, model_name: str) -> dict[str, float]:
@@ -219,14 +51,14 @@ def _read_viterbi_biases(path: Path, model_name: str) -> dict[str, float]:
         raise ValueError(
             f"DETECTOR_MODEL {model_name!r} has an invalid {_VITERBI_CALIBRATION}: {exc}"
         ) from exc
-    if not isinstance(biases, Mapping) or set(biases) != set(_VITERBI_BIAS_KEYS):
+    if not isinstance(biases, Mapping) or set(biases) != set(VITERBI_BIAS_KEYS):
         raise ValueError(
             f"DETECTOR_MODEL {model_name!r} has an invalid {_VITERBI_CALIBRATION}: "
-            f"biases must contain exactly {', '.join(_VITERBI_BIAS_KEYS)}"
+            f"biases must contain exactly {', '.join(VITERBI_BIAS_KEYS)}"
         )
 
     normalized: dict[str, float] = {}
-    for key in _VITERBI_BIAS_KEYS:
+    for key in VITERBI_BIAS_KEYS:
         value = biases[key]
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise ValueError(
@@ -243,7 +75,7 @@ def _read_viterbi_biases(path: Path, model_name: str) -> dict[str, float]:
 
 
 def _load_viterbi_biases(model_name: str) -> dict[str, float]:
-    default: dict[str, float] = {key: 0.0 for key in _VITERBI_BIAS_KEYS}
+    default = default_viterbi_biases()
     try:
         model_path = Path(model_name).expanduser()
     except RuntimeError:
@@ -383,118 +215,7 @@ def _offset_pair(value: object) -> tuple[int, int] | None:
     return start, end
 
 
-def _label_state(raw_label: str) -> tuple[str | None, str | None]:
-    match = _BOUNDARY_RE.fullmatch(raw_label)
-    if match is None:
-        return None, None
-    boundary, native_label = match.groups()
-    if native_label not in _LABEL_TO_TYPE:
-        return None, None
-    return boundary, native_label
-
-
-def _transition_bias(
-    previous: tuple[str | None, str | None],
-    following: tuple[str | None, str | None],
-    boundaries: Mapping[str, set[str]],
-) -> float | None:
-    previous_boundary, previous_label = previous
-    following_boundary, following_label = following
-    previous_is_background = previous_label is None
-    following_is_background = following_label is None
-
-    if previous_is_background:
-        if following_is_background:
-            return _viterbi_biases["transition_bias_background_stay"]
-        if following_boundary in {"B", "S"}:
-            return _viterbi_biases["transition_bias_background_to_start"]
-        return None
-
-    previous_is_bio = boundaries.get(previous_label) == {"B", "I"}
-    if previous_is_bio:
-        if following_label == previous_label and following_boundary == "I":
-            return _viterbi_biases["transition_bias_inside_to_continue"]
-        if following_is_background:
-            return _viterbi_biases["transition_bias_end_to_background"]
-        if following_boundary in {"B", "S"}:
-            return _viterbi_biases["transition_bias_end_to_start"]
-        return None
-
-    if previous_boundary in {"B", "I"}:
-        if following_label != previous_label:
-            return None
-        if following_boundary == "I":
-            return _viterbi_biases["transition_bias_inside_to_continue"]
-        if following_boundary == "E":
-            return _viterbi_biases["transition_bias_inside_to_end"]
-        return None
-
-    if previous_boundary in {"E", "S"}:
-        if following_is_background:
-            return _viterbi_biases["transition_bias_end_to_background"]
-        if following_boundary in {"B", "S"}:
-            return _viterbi_biases["transition_bias_end_to_start"]
-    return None
-
-
-def _viterbi_decode(log_probabilities: Any) -> list[int]:
-    """Return the highest-scoring structurally valid BIO/BIOES label path."""
-
-    import torch
-
-    if log_probabilities.ndim != 2:
-        raise ValueError("OpenAI Privacy Filter logits must have shape [tokens, labels]")
-    sequence_length, class_count = log_probabilities.shape
-    if sequence_length == 0:
-        return []
-
-    states = [_label_state(_id2label.get(index, "O")) for index in range(class_count)]
-    boundaries: dict[str, set[str]] = {}
-    for boundary, native_label in states:
-        if boundary is not None and native_label is not None:
-            boundaries.setdefault(native_label, set()).add(boundary)
-
-    negative_infinity = -1e9
-    start_scores = torch.full_like(log_probabilities[0], negative_infinity)
-    end_scores = torch.full_like(log_probabilities[0], negative_infinity)
-    transition_scores = torch.full(
-        (class_count, class_count),
-        negative_infinity,
-        device=log_probabilities.device,
-        dtype=log_probabilities.dtype,
-    )
-
-    for index, (boundary, native_label) in enumerate(states):
-        is_background = native_label is None
-        is_bio = native_label is not None and boundaries.get(native_label) == {"B", "I"}
-        if is_background or boundary in {"B", "S"}:
-            start_scores[index] = 0.0
-        if is_background or boundary in {"E", "S"} or (is_bio and boundary in {"B", "I"}):
-            end_scores[index] = 0.0
-        for following_index, following in enumerate(states):
-            bias = _transition_bias((boundary, native_label), following, boundaries)
-            if bias is not None:
-                transition_scores[index, following_index] = bias
-
-    scores = log_probabilities[0] + start_scores
-    backpointers = []
-    for token_index in range(1, sequence_length):
-        paths = scores.unsqueeze(1) + transition_scores
-        best_scores, best_previous = paths.max(dim=0)
-        scores = best_scores + log_probabilities[token_index]
-        backpointers.append(best_previous)
-
-    scores = scores + end_scores
-    last_label = int(scores.argmax())
-    path = [last_label]
-    for previous in reversed(backpointers):
-        last_label = int(previous[last_label])
-        path.append(last_label)
-    path.reverse()
-    return path
-
-
-def _predict_windows(text: str) -> list[list[_TokenPrediction]]:
+def _predict_windows(text: str) -> list[list[TokenPrediction]]:
     import torch
 
     max_tokens = _model_max_tokens()
@@ -522,7 +243,7 @@ def _predict_windows(text: str) -> list[list[_TokenPrediction]]:
     except (AttributeError, StopIteration, TypeError):
         device = None
 
-    predictions: list[list[_TokenPrediction]] = []
+    predictions: list[list[TokenPrediction]] = []
     for window_index, input_ids in enumerate(input_windows):
         attention = (
             attention_windows[window_index]
@@ -544,7 +265,6 @@ def _predict_windows(text: str) -> list[list[_TokenPrediction]]:
             output = _model(**model_inputs)
             logits = output["logits"] if isinstance(output, Mapping) else output.logits
 
-        window_predictions: list[_TokenPrediction] = []
         token_count = min(
             len(input_ids),
             len(attention),
@@ -560,9 +280,8 @@ def _predict_windows(text: str) -> list[list[_TokenPrediction]]:
             if offset is None:
                 continue
             start, end = offset
-            if not 0 <= start < end <= len(text):
-                continue
-            active_tokens.append((token_index, start, end))
+            if 0 <= start < end <= len(text):
+                active_tokens.append((token_index, start, end))
 
         if not active_tokens:
             predictions.append([])
@@ -572,136 +291,18 @@ def _predict_windows(text: str) -> list[list[_TokenPrediction]]:
         active_log_probabilities = log_probabilities[
             [token_index for token_index, _, _ in active_tokens]
         ]
-        label_ids = _viterbi_decode(active_log_probabilities)
+        label_ids = viterbi_decode(active_log_probabilities, _id2label, _viterbi_biases)
         probabilities = active_log_probabilities.exp()
+        window_predictions: list[TokenPrediction] = []
         for prediction_index, ((_, start, end), label_id) in enumerate(
             zip(active_tokens, label_ids, strict=True)
         ):
             label = _id2label.get(label_id)
             score = _finite_score(probabilities[prediction_index, label_id])
-            if label is None or score is None:
-                continue
-            window_predictions.append(_TokenPrediction(label, start, end, score))
+            if label is not None and score is not None:
+                window_predictions.append(TokenPrediction(label, start, end, score))
         predictions.append(window_predictions)
     return predictions
-
-
-def _reconstruct_window(
-    predictions: Sequence[_TokenPrediction],
-    text_length: int,
-) -> list[_Candidate]:
-    spans: list[_Candidate] = []
-    current_label: str | None = None
-    current_type: str | None = None
-    start = 0
-    end = 0
-    scores: list[float] = []
-
-    def close_current() -> None:
-        nonlocal current_label, current_type, end, scores, start
-        if (
-            current_label is not None
-            and current_type is not None
-            and scores
-            and 0 <= start < end <= text_length
-        ):
-            spans.append(
-                _Candidate(
-                    current_label,
-                    current_type,
-                    start,
-                    end,
-                    sum(scores) / len(scores),
-                )
-            )
-        current_label = None
-        current_type = None
-        start = 0
-        end = 0
-        scores = []
-
-    def start_current(native_label: str, entity_type: str, token: _TokenPrediction) -> None:
-        nonlocal current_label, current_type, end, scores, start
-        current_label = native_label
-        current_type = entity_type
-        start = token.start
-        end = token.end
-        scores = [token.score]
-
-    for token in predictions:
-        match = _BOUNDARY_RE.fullmatch(token.label)
-        if match is None:
-            close_current()
-            continue
-        boundary, native_label = match.groups()
-        entity_type = _LABEL_TO_TYPE.get(native_label)
-        if entity_type is None:
-            # Compatible fine-tunes may add categories that PasteGuard does not
-            # expose. Treat them as background rather than inventing a type.
-            close_current()
-            continue
-
-        if boundary == "S":
-            close_current()
-            start_current(native_label, entity_type, token)
-            close_current()
-        elif boundary == "B":
-            close_current()
-            start_current(native_label, entity_type, token)
-        elif boundary == "I":
-            if current_label != native_label:
-                close_current()
-                start_current(native_label, entity_type, token)
-            else:
-                end = max(end, token.end)
-                scores.append(token.score)
-        elif boundary == "E":
-            if current_label != native_label:
-                close_current()
-                start_current(native_label, entity_type, token)
-            else:
-                end = max(end, token.end)
-                scores.append(token.score)
-            close_current()
-
-    close_current()
-    return spans
-
-
-def _consolidate_candidates(candidates: Sequence[_Candidate]) -> list[_Candidate]:
-    # Exact duplicates occur in overlapping tokenizer windows. Keep the
-    # strongest instance, then join overlapping or touching fragments of the
-    # same model category before whitespace trimming and thresholding.
-    best: dict[tuple[str, int, int], _Candidate] = {}
-    for candidate in candidates:
-        key = (candidate.native_label, candidate.start, candidate.end)
-        if key not in best or candidate.score > best[key].score:
-            best[key] = candidate
-
-    consolidated: list[_Candidate] = []
-    for candidate in sorted(
-        best.values(),
-        key=lambda item: (item.native_label, item.start, -item.end, -item.score),
-    ):
-        previous = consolidated[-1] if consolidated else None
-        if (
-            previous is not None
-            and previous.native_label == candidate.native_label
-            and candidate.start <= previous.end
-        ):
-            extends_span = candidate.end > previous.end
-            consolidated[-1] = _Candidate(
-                previous.native_label,
-                previous.entity_type,
-                previous.start,
-                max(previous.end, candidate.end),
-                max(previous.score, candidate.score) if extends_span else previous.score,
-            )
-        else:
-            consolidated.append(candidate)
-
-    consolidated.sort(key=lambda item: (item.start, item.end, item.entity_type))
-    return consolidated
 
 
 def detect_openai_privacy_filter(text: str, score_threshold: float = 0.0) -> list[Span]:
@@ -715,11 +316,11 @@ def detect_openai_privacy_filter(text: str, score_threshold: float = 0.0) -> lis
     with _infer_lock:
         windows = _predict_windows(text)
 
-    candidates = _consolidate_candidates(
+    candidates = consolidate_candidates(
         [
             candidate
             for predictions in windows
-            for candidate in _reconstruct_window(predictions, len(text))
+            for candidate in reconstruct_window(predictions, len(text))
         ]
     )
 
@@ -731,12 +332,5 @@ def detect_openai_privacy_filter(text: str, score_threshold: float = 0.0) -> lis
         while start < end and text[end - 1].isspace():
             end -= 1
         if start < end and candidate.score >= score_threshold:
-            spans.append(
-                Span(
-                    candidate.entity_type,
-                    start,
-                    end,
-                    candidate.score,
-                )
-            )
+            spans.append(Span(candidate.entity_type, start, end, candidate.score))
     return spans

--- a/detector/detector/semantic_backend.py
+++ b/detector/detector/semantic_backend.py
@@ -22,12 +22,19 @@ from huggingface_hub.utils import (
     validate_repo_id,  # pyright: ignore[reportPrivateImportUsage]
 )
 
-from . import gliner_layer
+from . import gliner_layer, openai_privacy_filter_layer
 from .entities import Span
 
 DEFAULT_BACKEND = "gliner"
 _GLINER_CONFIG = "gliner_config.json"
 _GLINER_WEIGHTS = ("model.safetensors", "pytorch_model.bin")
+_PRIVACY_FILTER_CONFIG = "config.json"
+_TRANSFORMER_WEIGHTS = (
+    "model.safetensors",
+    "model.safetensors.index.json",
+    "pytorch_model.bin",
+    "pytorch_model.bin.index.json",
+)
 
 
 class SemanticBackend(Protocol):
@@ -74,6 +81,15 @@ def _build_gliner(model: str) -> SemanticBackend:
     )
 
 
+def _build_openai_privacy_filter(model: str) -> SemanticBackend:
+    return _FunctionBackend(
+        name="openai_privacy_filter",
+        model=model,
+        _load_model=openai_privacy_filter_layer.load_model,
+        _detect=openai_privacy_filter_layer.detect_openai_privacy_filter,
+    )
+
+
 _backend: SemanticBackend | None = None
 _backend_lock = threading.Lock()
 
@@ -87,18 +103,45 @@ def _configured_model() -> tuple[str | None, str]:
     return model or None, "DETECTOR_MODEL"
 
 
-def _validate_gliner_config(config_path: Path, model: str, source_name: str) -> None:
+def _read_json_config(
+    config_path: Path,
+    configured_value: str,
+    source_name: str,
+    filename: str,
+) -> dict[str, object]:
     try:
         config = json.loads(config_path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise ValueError(
-            f"{source_name} {model!r} has an unreadable {_GLINER_CONFIG}: {exc}"
+            f"{source_name} {configured_value!r} has an unreadable {filename}: {exc}"
         ) from exc
     if not isinstance(config, dict):
         raise ValueError(
-            f"{source_name} {model!r} has an invalid {_GLINER_CONFIG}: "
+            f"{source_name} {configured_value!r} has an invalid {filename}: "
             "the top-level value must be an object"
         )
+    return config
+
+
+def _validate_gliner_config(config_path: Path, model: str, source_name: str) -> None:
+    _read_json_config(config_path, model, source_name, _GLINER_CONFIG)
+
+
+def _validate_privacy_filter_config(
+    config_path: Path,
+    configured_value: str,
+    source_name: str,
+) -> None:
+    config = _read_json_config(
+        config_path,
+        configured_value,
+        source_name,
+        _PRIVACY_FILTER_CONFIG,
+    )
+    openai_privacy_filter_layer.validate_label_set(
+        config.get("id2label"),
+        configured_value,
+    )
 
 
 def _validate_local_gliner_model(path: Path, configured_value: str, source_name: str) -> str:
@@ -185,12 +228,99 @@ def _resolve_gliner_model(
     return value
 
 
+def _validate_local_privacy_filter_model(
+    path: Path,
+    configured_value: str,
+    source_name: str,
+) -> str:
+    if not path.is_dir():
+        raise ValueError(f"{source_name} local path is not a directory: {configured_value}")
+
+    config_path = path / _PRIVACY_FILTER_CONFIG
+    if not config_path.is_file():
+        raise ValueError(
+            f"{source_name} is not a complete OpenAI Privacy Filter checkpoint: "
+            f"missing {_PRIVACY_FILTER_CONFIG} in {configured_value}"
+        )
+    _validate_privacy_filter_config(config_path, configured_value, source_name)
+
+    if not any((path / filename).is_file() for filename in _TRANSFORMER_WEIGHTS):
+        expected = " or ".join(_TRANSFORMER_WEIGHTS)
+        raise ValueError(
+            f"{source_name} is not a complete OpenAI Privacy Filter checkpoint: "
+            f"missing {expected} in {configured_value}"
+        )
+    return str(path.resolve())
+
+
+def _validate_remote_privacy_filter_model(model: str, source_name: str) -> None:
+    try:
+        config_path = Path(hf_hub_download(model, _PRIVACY_FILTER_CONFIG))
+    except RemoteEntryNotFoundError:
+        raise ValueError(
+            f"{source_name} {model!r} is not an OpenAI Privacy Filter checkpoint: "
+            f"missing {_PRIVACY_FILTER_CONFIG}"
+        ) from None
+    except RepositoryNotFoundError:
+        raise ValueError(
+            f"{source_name} {model!r} was not found or is not accessible; "
+            "check the Hugging Face model ID and authentication"
+        ) from None
+    except LocalEntryNotFoundError:
+        raise ValueError(
+            f"{source_name} {model!r} could not be validated because "
+            f"{_PRIVACY_FILTER_CONFIG} is not cached and Hugging Face is unavailable"
+        ) from None
+    except HfHubHTTPError as exc:
+        raise ValueError(
+            f"{source_name} {model!r} could not be validated with Hugging Face: {exc}"
+        ) from exc
+
+    _validate_privacy_filter_config(config_path, model, source_name)
+
+
+def _resolve_openai_privacy_filter_model(
+    configured_value: str,
+    is_default: bool = False,
+    source_name: str = "DETECTOR_MODEL",
+) -> str:
+    value = configured_value.strip()
+    if not value:
+        raise ValueError(f"{source_name} must not be blank")
+
+    try:
+        path = Path(value).expanduser()
+    except RuntimeError:
+        path = Path(value)
+    if path.exists():
+        return _validate_local_privacy_filter_model(path, configured_value, source_name)
+    if _looks_like_local_path(value):
+        raise ValueError(f"{source_name} local path does not exist: {configured_value}")
+
+    try:
+        validate_repo_id(value)
+    except HFValidationError:
+        raise ValueError(
+            f"{source_name} {configured_value!r} is neither an existing local "
+            "directory nor a valid Hugging Face model ID"
+        ) from None
+
+    if not is_default:
+        _validate_remote_privacy_filter_model(value, source_name)
+    return value
+
+
 _BACKENDS = {
     "gliner": _BackendDefinition(
         default_model=gliner_layer.DEFAULT_MODEL,
         resolve_model=_resolve_gliner_model,
         build=_build_gliner,
-    )
+    ),
+    "openai_privacy_filter": _BackendDefinition(
+        default_model=openai_privacy_filter_layer.DEFAULT_MODEL,
+        resolve_model=_resolve_openai_privacy_filter_model,
+        build=_build_openai_privacy_filter,
+    ),
 }
 
 

--- a/detector/detector/semantic_backend.py
+++ b/detector/detector/semantic_backend.py
@@ -22,7 +22,7 @@ from huggingface_hub.utils import (
     validate_repo_id,  # pyright: ignore[reportPrivateImportUsage]
 )
 
-from . import gliner_layer, openai_privacy_filter_layer
+from . import gliner_layer, openai_privacy_filter_labels, openai_privacy_filter_layer
 from .entities import Span
 
 DEFAULT_BACKEND = "gliner"
@@ -138,7 +138,7 @@ def _validate_privacy_filter_config(
         source_name,
         _PRIVACY_FILTER_CONFIG,
     )
-    openai_privacy_filter_layer.validate_label_set(
+    openai_privacy_filter_labels.validate_label_set(
         config.get("id2label"),
         configured_value,
     )

--- a/detector/tests/test_openai_privacy_filter_layer.py
+++ b/detector/tests/test_openai_privacy_filter_layer.py
@@ -36,11 +36,13 @@ def reset_backend(monkeypatch):
     monkeypatch.setattr(layer, "_model", None)
     monkeypatch.setattr(layer, "_id2label", {})
     monkeypatch.setattr(layer, "_loaded_model_name", None)
+    monkeypatch.setattr(layer, "_inference_max_tokens", layer._DEFAULT_MAX_TOKENS)
     monkeypatch.setattr(
         layer,
         "_viterbi_biases",
         default_viterbi_biases(),
     )
+    layer._candidate_cache.clear()
 
 
 def _checkpoint_labels(boundaries: str = "BIES", extras: tuple[str, ...] = ()) -> list[str]:
@@ -63,9 +65,12 @@ def _token(label: str, start: int, end: int, score: float = 0.9):
 
 
 def _loaded_stub(monkeypatch, windows):
+    assert len(windows) == 1
     monkeypatch.setattr(layer, "_tokenizer", Mock())
     monkeypatch.setattr(layer, "_model", Mock())
-    monkeypatch.setattr(layer, "_predict_windows", Mock(return_value=windows))
+    predict = Mock(return_value=windows[0])
+    monkeypatch.setattr(layer, "_predict_tokens", predict)
+    return predict
 
 
 def test_loads_and_validates_checkpoint_once(monkeypatch):
@@ -98,6 +103,20 @@ def test_loaded_checkpoint_cannot_be_replaced(monkeypatch):
 
     with pytest.raises(RuntimeError, match="already loaded"):
         layer.load_model("org/another-privacy-filter")
+
+
+def test_configured_max_tokens_can_be_overridden(monkeypatch):
+    monkeypatch.setenv("OPENAI_PRIVACY_FILTER_MAX_TOKENS", "1024")
+
+    assert layer._configured_max_tokens() == 1024
+
+
+@pytest.mark.parametrize("value", ["invalid", "255"])
+def test_invalid_configured_max_tokens_fail_clearly(monkeypatch, value):
+    monkeypatch.setenv("OPENAI_PRIVACY_FILTER_MAX_TOKENS", value)
+
+    with pytest.raises(ValueError, match="must be an integer of at least 256"):
+        layer._configured_max_tokens()
 
 
 @pytest.mark.parametrize("boundaries", ["BI", "BIES"])
@@ -304,67 +323,26 @@ def test_bioes_reconstruction_handles_single_and_complete_spans(monkeypatch):
     ]
 
 
-def test_touching_bioes_fragments_coalesce_before_thresholding(monkeypatch):
-    text = "AliceBob"
+def test_adjacent_complete_person_spans_remain_separate(monkeypatch):
+    text = "Alice Smith Bob Jones"
     _loaded_stub(
         monkeypatch,
         [
             [
-                _token("S-private_person", 0, 5, 0.8),
-                _token("S-private_person", 5, 8, 0.6),
-            ]
-        ],
-    )
-
-    spans = layer.detect_openai_privacy_filter(text, 0.7)
-
-    assert spans == [Span(PERSON, 0, 8, 0.8)]
-
-
-def test_reference_person_fragments_coalesce_before_whitespace_trimming(monkeypatch):
-    text = (
-        "Quindle Testwick can be reached at quindle.testwick@openai.com "
-        "or (415) 555-0102 before 2026-05-17."
-    )
-    _loaded_stub(
-        monkeypatch,
-        [
-            [
-                _token("B-private_person", 0, 2),
-                _token("E-private_person", 2, 7),
-                _token("B-private_person", 7, 12),
-                _token("E-private_person", 12, 16),
+                _token("B-private_person", 0, 5, 0.95),
+                _token("E-private_person", 5, 11, 0.95),
+                _token("B-private_person", 11, 15, 0.96),
+                _token("E-private_person", 15, 21, 0.96),
             ]
         ],
     )
 
     spans = layer.detect_openai_privacy_filter(text)
 
-    assert spans == [Span(PERSON, 0, 16, 0.9)]
-    assert text[spans[0].start : spans[0].end] == "Quindle Testwick"
-
-
-def test_reference_address_fragments_coalesce_before_whitespace_trimming(monkeypatch):
-    text = (
-        "Support ticket notes: phone +1 999 555-1234, address 404 Nowhere Lane, "
-        "and passphrase Priv4cy-Filt3r-2026."
-    )
-    _loaded_stub(
-        monkeypatch,
-        [
-            [
-                _token("S-private_address", 53, 56),
-                _token("B-private_address", 56, 60),
-                _token("I-private_address", 60, 64),
-                _token("E-private_address", 64, 69),
-            ]
-        ],
-    )
-
-    spans = layer.detect_openai_privacy_filter(text)
-
-    assert spans == [Span(LOCATION, 53, 69, 0.9)]
-    assert text[spans[0].start : spans[0].end] == "404 Nowhere Lane"
+    assert spans == [
+        Span(PERSON, 0, 11, 0.95),
+        Span(PERSON, 12, 21, 0.96),
+    ]
 
 
 def test_unsupported_labels_are_deliberately_ignored(monkeypatch):
@@ -420,26 +398,57 @@ def test_character_offsets_remain_exact_after_astral_unicode(monkeypatch):
     assert text[spans[0].start : spans[0].end] == "Alice"
 
 
-def test_overlapping_windows_deduplicate_and_prefer_complete_span(monkeypatch):
-    text = "Alice Smith"
-    _loaded_stub(
-        monkeypatch,
-        [
-            [_token("B-private_person", 0, 5), _token("I-private_person", 6, 11)],
-            [_token("S-private_person", 6, 11, 0.95)],
-        ],
-    )
-
-    spans = layer.detect_openai_privacy_filter(text)
-
-    assert spans == [Span(PERSON, 0, 11, 0.9)]
-
-
-def test_inference_uses_safe_overlapping_tokenizer_windows(monkeypatch):
+def test_tokens_with_the_same_unicode_offset_remain_distinct(monkeypatch):
     torch = pytest.importorskip("torch")
 
     class FakeTokenizer:
-        model_max_length = 16
+        model_max_length = 2048
+
+        def num_special_tokens_to_add(self, pair=False):
+            assert pair is False
+            return 0
+
+        def __call__(self, _text, **_kwargs):
+            return {
+                "input_ids": [[10, 11]],
+                "attention_mask": [[1, 1]],
+                "offset_mapping": [[(0, 1), (0, 1)]],
+                "special_tokens_mask": [[0, 0]],
+            }
+
+    class FakeModel:
+        config = SimpleNamespace(max_position_embeddings=2048)
+
+        def parameters(self):
+            yield torch.nn.Parameter(torch.empty(0))
+
+        def __call__(self, **_kwargs):
+            return SimpleNamespace(
+                logits=torch.tensor([[[8.0, 0.0], [0.0, 8.0]]]),
+            )
+
+    monkeypatch.setattr(layer, "_tokenizer", FakeTokenizer())
+    monkeypatch.setattr(layer, "_model", FakeModel())
+    monkeypatch.setattr(layer, "_id2label", {0: "O", 1: "S-private_person"})
+
+    predictions = layer._predict_tokens("𐍈")
+
+    assert [(prediction.label, prediction.start, prediction.end) for prediction in predictions] == [
+        ("O", 0, 1),
+        ("S-private_person", 0, 1),
+    ]
+
+
+def test_inference_stitches_overlapping_token_scores_before_global_viterbi(monkeypatch):
+    torch = pytest.importorskip("torch")
+    text = "x" * 132
+    first_ids = list(range(1000, 1130))
+    second_ids = [*first_ids[2:], 2000, 2001]
+    first_offsets = [(index, index + 1) for index in range(130)]
+    second_offsets = [(index, index + 1) for index in range(2, 132)]
+
+    class FakeTokenizer:
+        model_max_length = 128000
         is_fast = True
 
         def __init__(self):
@@ -452,38 +461,66 @@ def test_inference_uses_safe_overlapping_tokenizer_windows(monkeypatch):
         def __call__(self, text, **kwargs):
             self.call(text, **kwargs)
             return {
-                "input_ids": [[10, 11]],
-                "attention_mask": [[1, 1]],
-                "offset_mapping": [[(0, 5), (6, 9)]],
-                "special_tokens_mask": [[0, 0]],
+                "input_ids": [first_ids, second_ids],
+                "attention_mask": [[1] * 130, [1] * 130],
+                "offset_mapping": [first_offsets, second_offsets],
+                "special_tokens_mask": [[0] * 130, [0] * 130],
             }
 
     class FakeModel:
-        config = SimpleNamespace(max_position_embeddings=16)
+        config = SimpleNamespace(max_position_embeddings=131072)
+
+        def __init__(self):
+            self.calls = 0
 
         def parameters(self):
             yield torch.nn.Parameter(torch.empty(0))
 
         def __call__(self, **_kwargs):
-            return SimpleNamespace(
-                logits=torch.tensor([[[0.0, 4.0], [4.0, 0.0]]]),
-            )
+            self.calls += 1
+            logits = torch.zeros((1, 130, 3))
+            logits[:, :, 0] = 8.0
+            entity_start = 128 if self.calls == 1 else 126
+            logits[0, entity_start] = torch.tensor([0.0, 10.0, 0.0])
+            logits[0, entity_start + 1] = torch.tensor([0.0, 0.0, 10.0])
+            return SimpleNamespace(logits=logits)
 
     tokenizer = FakeTokenizer()
+    model = FakeModel()
     monkeypatch.setattr(layer, "_tokenizer", tokenizer)
-    monkeypatch.setattr(layer, "_model", FakeModel())
-    monkeypatch.setattr(layer, "_id2label", {0: "O", 1: "S-private_person"})
+    monkeypatch.setattr(layer, "_model", model)
+    monkeypatch.setattr(
+        layer,
+        "_id2label",
+        {0: "O", 1: "B-private_person", 2: "E-private_person"},
+    )
 
-    spans = layer.detect_openai_privacy_filter("Alice met")
+    spans = layer.detect_openai_privacy_filter(text)
 
+    assert len(spans) == 1
     assert spans[0].entity_type == PERSON
+    assert (spans[0].start, spans[0].end) == (128, 130)
+    assert model.calls == 2
     tokenizer.call.assert_called_once_with(
-        "Alice met",
+        text,
         truncation=True,
-        max_length=16,
-        stride=4,
+        max_length=2048,
+        stride=128,
         return_overflowing_tokens=True,
         return_offsets_mapping=True,
         return_special_tokens_mask=True,
         padding=False,
     )
+
+
+def test_repeated_text_reuses_compact_candidate_cache(monkeypatch):
+    predict = _loaded_stub(
+        monkeypatch,
+        [[_token("S-private_person", 0, 5, 0.95)]],
+    )
+
+    first = layer.detect_openai_privacy_filter("Alice")
+    second = layer.detect_openai_privacy_filter("Alice")
+
+    assert first == second == [Span(PERSON, 0, 5, 0.95)]
+    predict.assert_called_once_with("Alice")

--- a/detector/tests/test_openai_privacy_filter_layer.py
+++ b/detector/tests/test_openai_privacy_filter_layer.py
@@ -39,6 +39,11 @@ def reset_backend(monkeypatch):
     monkeypatch.setattr(layer, "_inference_max_tokens", layer._DEFAULT_MAX_TOKENS)
     monkeypatch.setattr(
         layer,
+        "_inference_stride_tokens",
+        layer._WINDOW_OVERLAP_TOKENS,
+    )
+    monkeypatch.setattr(
+        layer,
         "_viterbi_biases",
         default_viterbi_biases(),
     )
@@ -55,7 +60,10 @@ def _checkpoint_labels(boundaries: str = "BIES", extras: tuple[str, ...] = ()) -
 
 def _model_with_labels(labels: list[str]):
     model = Mock()
-    model.config.id2label = dict(enumerate(labels))
+    model.config = SimpleNamespace(
+        id2label=dict(enumerate(labels)),
+        max_position_embeddings=131072,
+    )
     model.eval = Mock()
     return model
 
@@ -74,7 +82,8 @@ def _loaded_stub(monkeypatch, windows):
 
 
 def test_loads_and_validates_checkpoint_once(monkeypatch):
-    tokenizer = Mock(is_fast=True)
+    tokenizer = Mock(is_fast=True, model_max_length=128000)
+    tokenizer.num_special_tokens_to_add.return_value = 2
     model = _model_with_labels(_checkpoint_labels())
     biases = default_viterbi_biases()
     create = Mock(return_value=(tokenizer, model, biases))
@@ -90,7 +99,8 @@ def test_loads_and_validates_checkpoint_once(monkeypatch):
 
 
 def test_loaded_checkpoint_cannot_be_replaced(monkeypatch):
-    tokenizer = Mock(is_fast=True)
+    tokenizer = Mock(is_fast=True, model_max_length=128000)
+    tokenizer.num_special_tokens_to_add.return_value = 2
     model = _model_with_labels(_checkpoint_labels())
     biases = default_viterbi_biases()
     monkeypatch.setattr(
@@ -103,6 +113,42 @@ def test_loaded_checkpoint_cannot_be_replaced(monkeypatch):
 
     with pytest.raises(RuntimeError, match="already loaded"):
         layer.load_model("org/another-privacy-filter")
+
+
+def test_checkpoint_without_finite_token_limit_fails_at_startup(monkeypatch):
+    tokenizer = Mock(is_fast=True, model_max_length=layer._UNBOUNDED_MODEL_LENGTH)
+    tokenizer.num_special_tokens_to_add.return_value = 2
+    model = _model_with_labels(_checkpoint_labels())
+    del model.config.max_position_embeddings
+    monkeypatch.setattr(
+        layer,
+        "_create_components",
+        Mock(return_value=(tokenizer, model, default_viterbi_biases())),
+    )
+
+    with pytest.raises(ValueError, match="has no finite model_max_length"):
+        layer.load_model("org/unbounded-privacy-filter")
+
+    assert layer._model is None
+    assert layer._tokenizer is None
+
+
+def test_checkpoint_with_too_few_content_tokens_fails_at_startup(monkeypatch):
+    tokenizer = Mock(is_fast=True, model_max_length=2)
+    tokenizer.num_special_tokens_to_add.return_value = 2
+    model = _model_with_labels(_checkpoint_labels())
+    model.config.max_position_embeddings = 2
+    monkeypatch.setattr(
+        layer,
+        "_create_components",
+        Mock(return_value=(tokenizer, model, default_viterbi_biases())),
+    )
+
+    with pytest.raises(ValueError, match="model_max_length is too small for inference"):
+        layer.load_model("org/tiny-privacy-filter")
+
+    assert layer._model is None
+    assert layer._tokenizer is None
 
 
 def test_configured_max_tokens_can_be_overridden(monkeypatch):

--- a/detector/tests/test_openai_privacy_filter_layer.py
+++ b/detector/tests/test_openai_privacy_filter_layer.py
@@ -1,0 +1,494 @@
+"""Unit tests for the OpenAI Privacy Filter backend (no model downloads)."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import detector.openai_privacy_filter_layer as layer
+from detector.entities import (
+    ACCOUNT_NUMBER,
+    CREDIT_CARD,
+    DATE_TIME,
+    EMAIL_ADDRESS,
+    IBAN_CODE,
+    IP_ADDRESS,
+    LOCATION,
+    PERSON,
+    PHONE_NUMBER,
+    SECRET,
+    URL,
+    Span,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_backend(monkeypatch):
+    monkeypatch.setattr(layer, "_tokenizer", None)
+    monkeypatch.setattr(layer, "_model", None)
+    monkeypatch.setattr(layer, "_id2label", {})
+    monkeypatch.setattr(layer, "_loaded_model_name", None)
+    monkeypatch.setattr(
+        layer,
+        "_viterbi_biases",
+        dict.fromkeys(layer._VITERBI_BIAS_KEYS, 0.0),
+    )
+
+
+def _checkpoint_labels(boundaries: str = "BIES", extras: tuple[str, ...] = ()) -> list[str]:
+    return [
+        "O",
+        *[
+            f"{boundary}-{label}"
+            for label in sorted(layer._REQUIRED_LABELS)
+            for boundary in boundaries
+        ],
+        *extras,
+    ]
+
+
+def _model_with_labels(labels: list[str]):
+    model = Mock()
+    model.config.id2label = dict(enumerate(labels))
+    model.eval = Mock()
+    return model
+
+
+def _token(label: str, start: int, end: int, score: float = 0.9):
+    return layer._TokenPrediction(label, start, end, score)
+
+
+def _loaded_stub(monkeypatch, windows):
+    monkeypatch.setattr(layer, "_tokenizer", Mock())
+    monkeypatch.setattr(layer, "_model", Mock())
+    monkeypatch.setattr(layer, "_predict_windows", Mock(return_value=windows))
+
+
+def test_loads_and_validates_checkpoint_once(monkeypatch):
+    tokenizer = Mock(is_fast=True)
+    model = _model_with_labels(_checkpoint_labels())
+    biases = dict.fromkeys(layer._VITERBI_BIAS_KEYS, 0.0)
+    create = Mock(return_value=(tokenizer, model, biases))
+    monkeypatch.setattr(layer, "_create_components", create)
+
+    layer.load_model("/models/privacy-filter")
+    layer.load_model("/models/privacy-filter")
+
+    create.assert_called_once_with("/models/privacy-filter")
+    assert layer._tokenizer is tokenizer
+    assert layer._model is model
+    assert layer._viterbi_biases == biases
+
+
+def test_loaded_checkpoint_cannot_be_replaced(monkeypatch):
+    tokenizer = Mock(is_fast=True)
+    model = _model_with_labels(_checkpoint_labels())
+    biases = dict.fromkeys(layer._VITERBI_BIAS_KEYS, 0.0)
+    monkeypatch.setattr(
+        layer,
+        "_create_components",
+        Mock(return_value=(tokenizer, model, biases)),
+    )
+
+    layer.load_model("openai/privacy-filter")
+
+    with pytest.raises(RuntimeError, match="already loaded"):
+        layer.load_model("org/another-privacy-filter")
+
+
+@pytest.mark.parametrize("boundaries", ["BI", "BIES"])
+def test_complete_bio_and_bioes_label_sets_are_accepted(boundaries):
+    labels = _checkpoint_labels(boundaries)
+
+    normalized = layer.validate_label_set(dict(enumerate(labels)), "compatible/model")
+
+    assert normalized[0] == "O"
+    assert set(normalized.values()) == set(labels)
+
+
+def test_bilou_required_labels_fail_at_startup():
+    labels = _checkpoint_labels("BILU")
+
+    with pytest.raises(ValueError, match=r"unsupported boundary prefixes.*L,U"):
+        layer.validate_label_set(dict(enumerate(labels)), "org/bilou")
+
+
+def test_bilou_recognized_aliases_fail_at_startup():
+    labels = _checkpoint_labels(extras=("B-person", "I-person", "L-person", "U-person"))
+
+    with pytest.raises(ValueError, match=r"unsupported boundary prefixes.*person=L,U"):
+        layer.validate_label_set(dict(enumerate(labels)), "org/bilou-alias")
+
+
+def test_incompatible_generic_ner_checkpoint_fails_clearly():
+    labels = ["O", "B-PER", "I-PER", "B-LOC", "I-LOC"]
+
+    with pytest.raises(ValueError, match="not a Privacy Filter-compatible checkpoint"):
+        layer.validate_label_set(dict(enumerate(labels)), "dslim/bert-base-NER")
+
+
+def test_incomplete_boundary_scheme_fails_clearly():
+    labels = _checkpoint_labels()
+    labels.remove("S-secret")
+
+    with pytest.raises(ValueError, match=r"incomplete BIO/BIOES boundaries.*secret=B,E,I"):
+        layer.validate_label_set(dict(enumerate(labels)), "org/incomplete")
+
+
+def test_extra_unsupported_labels_are_allowed():
+    labels = _checkpoint_labels(
+        extras=("B-organization", "I-organization", "L-organization", "U-organization")
+    )
+
+    normalized = layer.validate_label_set(dict(enumerate(labels)), "org/extended")
+
+    assert "B-organization" in normalized.values()
+    assert "U-organization" in normalized.values()
+
+
+def test_viterbi_replaces_an_invalid_independent_argmax_path(monkeypatch):
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(
+        layer,
+        "_id2label",
+        {
+            0: "O",
+            1: "B-private_person",
+            2: "I-private_person",
+            3: "E-private_person",
+            4: "S-private_person",
+        },
+    )
+    log_probabilities = torch.tensor(
+        [
+            [0.0, 9.0, 10.0, 0.0, 0.0],
+            [10.0, 0.0, 0.0, 9.0, 0.0],
+        ]
+    )
+
+    assert log_probabilities.argmax(dim=-1).tolist() == [2, 0]
+    assert layer._viterbi_decode(log_probabilities) == [1, 3]
+
+
+def test_viterbi_supports_complete_bio_checkpoints(monkeypatch):
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(
+        layer,
+        "_id2label",
+        {
+            0: "O",
+            1: "B-private_person",
+            2: "I-private_person",
+        },
+    )
+    log_probabilities = torch.tensor(
+        [
+            [0.0, 9.0, 10.0],
+            [10.0, 0.0, 1.0],
+        ]
+    )
+
+    assert layer._viterbi_decode(log_probabilities) == [1, 0]
+
+
+def test_local_viterbi_calibration_is_loaded(tmp_path):
+    biases = {key: index / 10 for index, key in enumerate(layer._VITERBI_BIAS_KEYS, start=1)}
+    (tmp_path / "viterbi_calibration.json").write_text(
+        json.dumps({"operating_points": {"default": {"biases": biases}}})
+    )
+
+    assert layer._load_viterbi_biases(str(tmp_path)) == biases
+
+
+def test_invalid_local_viterbi_calibration_fails_clearly(tmp_path):
+    (tmp_path / "viterbi_calibration.json").write_text(
+        json.dumps({"operating_points": {"default": {"biases": {}}}})
+    )
+
+    with pytest.raises(ValueError, match=r"viterbi_calibration\.json"):
+        layer._load_viterbi_biases(str(tmp_path))
+
+
+def test_empty_text_does_not_require_loaded_model():
+    assert layer.detect_openai_privacy_filter("", 0.7) == []
+
+
+def test_non_empty_text_requires_loaded_model():
+    with pytest.raises(RuntimeError, match="not loaded"):
+        layer.detect_openai_privacy_filter("Alice", 0.7)
+
+
+def test_native_labels_map_to_canonical_entity_types(monkeypatch):
+    labels = [
+        ("account_number", ACCOUNT_NUMBER),
+        ("private_address", LOCATION),
+        ("private_date", DATE_TIME),
+        ("private_email", EMAIL_ADDRESS),
+        ("private_person", PERSON),
+        ("private_phone", PHONE_NUMBER),
+        ("private_url", URL),
+        ("secret", SECRET),
+    ]
+    text = " ".join("xx" for _ in labels)
+    windows = [
+        [
+            _token(f"S-{native}", index * 3, index * 3 + 2)
+            for index, (native, _) in enumerate(labels)
+        ]
+    ]
+    _loaded_stub(monkeypatch, windows)
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert [span.entity_type for span in spans] == [canonical for _, canonical in labels]
+
+
+def test_recognized_fine_tune_aliases_map_to_existing_canonical_types(monkeypatch):
+    aliases = [
+        ("credit_card", CREDIT_CARD),
+        ("iban_code", IBAN_CODE),
+        ("ip_address", IP_ADDRESS),
+    ]
+    text = "xx xx xx"
+    _loaded_stub(
+        monkeypatch,
+        [
+            [
+                _token(f"S-{native}", index * 3, index * 3 + 2)
+                for index, (native, _) in enumerate(aliases)
+            ]
+        ],
+    )
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert [span.entity_type for span in spans] == [canonical for _, canonical in aliases]
+
+
+def test_bio_reconstruction_merges_subwords_and_preserves_offsets(monkeypatch):
+    text = "Say Alice Smith today"
+    _loaded_stub(
+        monkeypatch,
+        [
+            [
+                _token("O", 0, 3),
+                _token("B-private_person", 4, 6, 0.8),
+                _token("I-private_person", 6, 9, 0.9),
+                _token("I-private_person", 10, 15, 1.0),
+                _token("O", 16, 21),
+            ]
+        ],
+    )
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert spans == [Span(PERSON, 4, 15, 0.9)]
+    assert text[spans[0].start : spans[0].end] == "Alice Smith"
+
+
+def test_bioes_reconstruction_handles_single_and_complete_spans(monkeypatch):
+    text = "Alice met Bob Stone"
+    _loaded_stub(
+        monkeypatch,
+        [
+            [
+                _token("S-private_person", 0, 5, 0.95),
+                _token("O", 6, 9),
+                _token("B-private_person", 10, 13, 0.8),
+                _token("E-private_person", 14, 19, 1.0),
+            ]
+        ],
+    )
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert spans == [
+        Span(PERSON, 0, 5, 0.95),
+        Span(PERSON, 10, 19, 0.9),
+    ]
+
+
+def test_touching_bioes_fragments_coalesce_before_thresholding(monkeypatch):
+    text = "AliceBob"
+    _loaded_stub(
+        monkeypatch,
+        [
+            [
+                _token("S-private_person", 0, 5, 0.8),
+                _token("S-private_person", 5, 8, 0.6),
+            ]
+        ],
+    )
+
+    spans = layer.detect_openai_privacy_filter(text, 0.7)
+
+    assert spans == [Span(PERSON, 0, 8, 0.8)]
+
+
+def test_reference_person_fragments_coalesce_before_whitespace_trimming(monkeypatch):
+    text = (
+        "Quindle Testwick can be reached at quindle.testwick@openai.com "
+        "or (415) 555-0102 before 2026-05-17."
+    )
+    _loaded_stub(
+        monkeypatch,
+        [
+            [
+                _token("B-private_person", 0, 2),
+                _token("E-private_person", 2, 7),
+                _token("B-private_person", 7, 12),
+                _token("E-private_person", 12, 16),
+            ]
+        ],
+    )
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert spans == [Span(PERSON, 0, 16, 0.9)]
+    assert text[spans[0].start : spans[0].end] == "Quindle Testwick"
+
+
+def test_reference_address_fragments_coalesce_before_whitespace_trimming(monkeypatch):
+    text = (
+        "Support ticket notes: phone +1 999 555-1234, address 404 Nowhere Lane, "
+        "and passphrase Priv4cy-Filt3r-2026."
+    )
+    _loaded_stub(
+        monkeypatch,
+        [
+            [
+                _token("S-private_address", 53, 56),
+                _token("B-private_address", 56, 60),
+                _token("I-private_address", 60, 64),
+                _token("E-private_address", 64, 69),
+            ]
+        ],
+    )
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert spans == [Span(LOCATION, 53, 69, 0.9)]
+    assert text[spans[0].start : spans[0].end] == "404 Nowhere Lane"
+
+
+def test_unsupported_labels_are_deliberately_ignored(monkeypatch):
+    text = "Alice at Acme Bob"
+    _loaded_stub(
+        monkeypatch,
+        [
+            [
+                _token("S-private_person", 0, 5),
+                _token("B-organization", 9, 11),
+                _token("I-organization", 11, 13),
+                _token("S-private_person", 14, 17),
+            ]
+        ],
+    )
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert spans == [
+        Span(PERSON, 0, 5, 0.9),
+        Span(PERSON, 14, 17, 0.9),
+    ]
+
+
+def test_score_threshold_applies_after_complete_span_reconstruction(monkeypatch):
+    text = "Alice"
+    _loaded_stub(
+        monkeypatch,
+        [[_token("B-private_person", 0, 2, 0.6), _token("E-private_person", 2, 5, 1.0)]],
+    )
+
+    assert layer.detect_openai_privacy_filter(text, 0.79) == [Span(PERSON, 0, 5, 0.8)]
+    assert layer.detect_openai_privacy_filter(text, 0.81) == []
+
+
+def test_span_whitespace_is_trimmed_after_reconstruction(monkeypatch):
+    text = " Alice "
+    _loaded_stub(
+        monkeypatch,
+        [[_token("B-private_person", 0, 3), _token("E-private_person", 3, 7)]],
+    )
+
+    assert layer.detect_openai_privacy_filter(text) == [Span(PERSON, 1, 6, 0.9)]
+
+
+def test_character_offsets_remain_exact_after_astral_unicode(monkeypatch):
+    text = "😀 Alice"
+    _loaded_stub(monkeypatch, [[_token("S-private_person", 2, 7)]])
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert spans == [Span(PERSON, 2, 7, 0.9)]
+    assert text[spans[0].start : spans[0].end] == "Alice"
+
+
+def test_overlapping_windows_deduplicate_and_prefer_complete_span(monkeypatch):
+    text = "Alice Smith"
+    _loaded_stub(
+        monkeypatch,
+        [
+            [_token("B-private_person", 0, 5), _token("I-private_person", 6, 11)],
+            [_token("S-private_person", 6, 11, 0.95)],
+        ],
+    )
+
+    spans = layer.detect_openai_privacy_filter(text)
+
+    assert spans == [Span(PERSON, 0, 11, 0.9)]
+
+
+def test_inference_uses_safe_overlapping_tokenizer_windows(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    class FakeTokenizer:
+        model_max_length = 16
+        is_fast = True
+
+        def __init__(self):
+            self.call = Mock()
+
+        def num_special_tokens_to_add(self, pair=False):
+            assert pair is False
+            return 0
+
+        def __call__(self, text, **kwargs):
+            self.call(text, **kwargs)
+            return {
+                "input_ids": [[10, 11]],
+                "attention_mask": [[1, 1]],
+                "offset_mapping": [[(0, 5), (6, 9)]],
+                "special_tokens_mask": [[0, 0]],
+            }
+
+    class FakeModel:
+        config = SimpleNamespace(max_position_embeddings=16)
+
+        def parameters(self):
+            yield torch.nn.Parameter(torch.empty(0))
+
+        def __call__(self, **_kwargs):
+            return SimpleNamespace(
+                logits=torch.tensor([[[0.0, 4.0], [4.0, 0.0]]]),
+            )
+
+    tokenizer = FakeTokenizer()
+    monkeypatch.setattr(layer, "_tokenizer", tokenizer)
+    monkeypatch.setattr(layer, "_model", FakeModel())
+    monkeypatch.setattr(layer, "_id2label", {0: "O", 1: "S-private_person"})
+
+    spans = layer.detect_openai_privacy_filter("Alice met")
+
+    assert spans[0].entity_type == PERSON
+    tokenizer.call.assert_called_once_with(
+        "Alice met",
+        truncation=True,
+        max_length=16,
+        stride=4,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        return_special_tokens_mask=True,
+        padding=False,
+    )

--- a/detector/tests/test_openai_privacy_filter_layer.py
+++ b/detector/tests/test_openai_privacy_filter_layer.py
@@ -21,6 +21,13 @@ from detector.entities import (
     URL,
     Span,
 )
+from detector.openai_privacy_filter_decoder import (
+    VITERBI_BIAS_KEYS,
+    TokenPrediction,
+    default_viterbi_biases,
+    viterbi_decode,
+)
+from detector.openai_privacy_filter_labels import REQUIRED_LABELS, validate_label_set
 
 
 @pytest.fixture(autouse=True)
@@ -32,18 +39,14 @@ def reset_backend(monkeypatch):
     monkeypatch.setattr(
         layer,
         "_viterbi_biases",
-        dict.fromkeys(layer._VITERBI_BIAS_KEYS, 0.0),
+        default_viterbi_biases(),
     )
 
 
 def _checkpoint_labels(boundaries: str = "BIES", extras: tuple[str, ...] = ()) -> list[str]:
     return [
         "O",
-        *[
-            f"{boundary}-{label}"
-            for label in sorted(layer._REQUIRED_LABELS)
-            for boundary in boundaries
-        ],
+        *[f"{boundary}-{label}" for label in sorted(REQUIRED_LABELS) for boundary in boundaries],
         *extras,
     ]
 
@@ -56,7 +59,7 @@ def _model_with_labels(labels: list[str]):
 
 
 def _token(label: str, start: int, end: int, score: float = 0.9):
-    return layer._TokenPrediction(label, start, end, score)
+    return TokenPrediction(label, start, end, score)
 
 
 def _loaded_stub(monkeypatch, windows):
@@ -68,7 +71,7 @@ def _loaded_stub(monkeypatch, windows):
 def test_loads_and_validates_checkpoint_once(monkeypatch):
     tokenizer = Mock(is_fast=True)
     model = _model_with_labels(_checkpoint_labels())
-    biases = dict.fromkeys(layer._VITERBI_BIAS_KEYS, 0.0)
+    biases = default_viterbi_biases()
     create = Mock(return_value=(tokenizer, model, biases))
     monkeypatch.setattr(layer, "_create_components", create)
 
@@ -84,7 +87,7 @@ def test_loads_and_validates_checkpoint_once(monkeypatch):
 def test_loaded_checkpoint_cannot_be_replaced(monkeypatch):
     tokenizer = Mock(is_fast=True)
     model = _model_with_labels(_checkpoint_labels())
-    biases = dict.fromkeys(layer._VITERBI_BIAS_KEYS, 0.0)
+    biases = default_viterbi_biases()
     monkeypatch.setattr(
         layer,
         "_create_components",
@@ -101,7 +104,7 @@ def test_loaded_checkpoint_cannot_be_replaced(monkeypatch):
 def test_complete_bio_and_bioes_label_sets_are_accepted(boundaries):
     labels = _checkpoint_labels(boundaries)
 
-    normalized = layer.validate_label_set(dict(enumerate(labels)), "compatible/model")
+    normalized = validate_label_set(dict(enumerate(labels)), "compatible/model")
 
     assert normalized[0] == "O"
     assert set(normalized.values()) == set(labels)
@@ -111,21 +114,21 @@ def test_bilou_required_labels_fail_at_startup():
     labels = _checkpoint_labels("BILU")
 
     with pytest.raises(ValueError, match=r"unsupported boundary prefixes.*L,U"):
-        layer.validate_label_set(dict(enumerate(labels)), "org/bilou")
+        validate_label_set(dict(enumerate(labels)), "org/bilou")
 
 
 def test_bilou_recognized_aliases_fail_at_startup():
     labels = _checkpoint_labels(extras=("B-person", "I-person", "L-person", "U-person"))
 
     with pytest.raises(ValueError, match=r"unsupported boundary prefixes.*person=L,U"):
-        layer.validate_label_set(dict(enumerate(labels)), "org/bilou-alias")
+        validate_label_set(dict(enumerate(labels)), "org/bilou-alias")
 
 
 def test_incompatible_generic_ner_checkpoint_fails_clearly():
     labels = ["O", "B-PER", "I-PER", "B-LOC", "I-LOC"]
 
     with pytest.raises(ValueError, match="not a Privacy Filter-compatible checkpoint"):
-        layer.validate_label_set(dict(enumerate(labels)), "dslim/bert-base-NER")
+        validate_label_set(dict(enumerate(labels)), "dslim/bert-base-NER")
 
 
 def test_incomplete_boundary_scheme_fails_clearly():
@@ -133,7 +136,7 @@ def test_incomplete_boundary_scheme_fails_clearly():
     labels.remove("S-secret")
 
     with pytest.raises(ValueError, match=r"incomplete BIO/BIOES boundaries.*secret=B,E,I"):
-        layer.validate_label_set(dict(enumerate(labels)), "org/incomplete")
+        validate_label_set(dict(enumerate(labels)), "org/incomplete")
 
 
 def test_extra_unsupported_labels_are_allowed():
@@ -141,25 +144,21 @@ def test_extra_unsupported_labels_are_allowed():
         extras=("B-organization", "I-organization", "L-organization", "U-organization")
     )
 
-    normalized = layer.validate_label_set(dict(enumerate(labels)), "org/extended")
+    normalized = validate_label_set(dict(enumerate(labels)), "org/extended")
 
     assert "B-organization" in normalized.values()
     assert "U-organization" in normalized.values()
 
 
-def test_viterbi_replaces_an_invalid_independent_argmax_path(monkeypatch):
+def test_viterbi_replaces_an_invalid_independent_argmax_path():
     torch = pytest.importorskip("torch")
-    monkeypatch.setattr(
-        layer,
-        "_id2label",
-        {
-            0: "O",
-            1: "B-private_person",
-            2: "I-private_person",
-            3: "E-private_person",
-            4: "S-private_person",
-        },
-    )
+    id2label = {
+        0: "O",
+        1: "B-private_person",
+        2: "I-private_person",
+        3: "E-private_person",
+        4: "S-private_person",
+    }
     log_probabilities = torch.tensor(
         [
             [0.0, 9.0, 10.0, 0.0, 0.0],
@@ -168,20 +167,16 @@ def test_viterbi_replaces_an_invalid_independent_argmax_path(monkeypatch):
     )
 
     assert log_probabilities.argmax(dim=-1).tolist() == [2, 0]
-    assert layer._viterbi_decode(log_probabilities) == [1, 3]
+    assert viterbi_decode(log_probabilities, id2label, default_viterbi_biases()) == [1, 3]
 
 
-def test_viterbi_supports_complete_bio_checkpoints(monkeypatch):
+def test_viterbi_supports_complete_bio_checkpoints():
     torch = pytest.importorskip("torch")
-    monkeypatch.setattr(
-        layer,
-        "_id2label",
-        {
-            0: "O",
-            1: "B-private_person",
-            2: "I-private_person",
-        },
-    )
+    id2label = {
+        0: "O",
+        1: "B-private_person",
+        2: "I-private_person",
+    }
     log_probabilities = torch.tensor(
         [
             [0.0, 9.0, 10.0],
@@ -189,11 +184,11 @@ def test_viterbi_supports_complete_bio_checkpoints(monkeypatch):
         ]
     )
 
-    assert layer._viterbi_decode(log_probabilities) == [1, 0]
+    assert viterbi_decode(log_probabilities, id2label, default_viterbi_biases()) == [1, 0]
 
 
 def test_local_viterbi_calibration_is_loaded(tmp_path):
-    biases = {key: index / 10 for index, key in enumerate(layer._VITERBI_BIAS_KEYS, start=1)}
+    biases = {key: index / 10 for index, key in enumerate(VITERBI_BIAS_KEYS, start=1)}
     (tmp_path / "viterbi_calibration.json").write_text(
         json.dumps({"operating_points": {"default": {"biases": biases}}})
     )

--- a/detector/tests/test_semantic_backend.py
+++ b/detector/tests/test_semantic_backend.py
@@ -1,5 +1,6 @@
 """Tests for semantic backend selection and model validation (no downloads)."""
 
+import json
 from unittest.mock import Mock
 
 import pytest
@@ -28,9 +29,34 @@ def _mock_gliner_loader(monkeypatch):
     return load
 
 
+def _mock_privacy_filter_loader(monkeypatch):
+    load = Mock()
+    monkeypatch.setattr(semantic_backend.openai_privacy_filter_layer, "load_model", load)
+    return load
+
+
 def _valid_local_model(path):
     path.mkdir(parents=True)
     (path / "gliner_config.json").write_text("{}")
+    (path / "model.safetensors").touch()
+    return path
+
+
+def _privacy_filter_id2label():
+    labels = [
+        "O",
+        *[
+            f"{boundary}-{label}"
+            for label in sorted(semantic_backend.openai_privacy_filter_layer._REQUIRED_LABELS)
+            for boundary in "BIES"
+        ],
+    ]
+    return dict(enumerate(labels))
+
+
+def _valid_local_privacy_filter_model(path):
+    path.mkdir(parents=True)
+    (path / "config.json").write_text(json.dumps({"id2label": _privacy_filter_id2label()}))
     (path / "model.safetensors").touch()
     return path
 
@@ -40,7 +66,7 @@ def _hub_error(error_type):
     return error_type("not found", response=response)
 
 
-def test_gliner_is_the_only_default_backend(monkeypatch):
+def test_gliner_remains_the_default_backend(monkeypatch):
     load = _mock_gliner_loader(monkeypatch)
     download_config = Mock()
     monkeypatch.setattr(semantic_backend, "hf_hub_download", download_config)
@@ -62,18 +88,35 @@ def test_explicit_gliner_selection(monkeypatch):
     load.assert_called_once_with("urchade/gliner_multi_pii-v1")
 
 
-@pytest.mark.parametrize("backend", ["unknown", "openai_privacy_filter"])
-def test_unknown_or_disabled_backend_fails_clearly(monkeypatch, backend):
+def test_unknown_backend_fails_clearly(monkeypatch):
+    backend = "unknown"
     monkeypatch.setenv("DETECTOR_BACKEND", backend)
     load = _mock_gliner_loader(monkeypatch)
 
     with pytest.raises(
         ValueError,
-        match=rf"Unknown DETECTOR_BACKEND {backend!r}. Supported backends: gliner",
+        match=(
+            rf"Unknown DETECTOR_BACKEND {backend!r}. Supported backends: "
+            "gliner, openai_privacy_filter"
+        ),
     ):
         semantic_backend.load_semantic_backend()
 
     load.assert_not_called()
+
+
+def test_openai_privacy_filter_uses_its_backend_default(monkeypatch):
+    monkeypatch.setenv("DETECTOR_BACKEND", "openai_privacy_filter")
+    load = _mock_privacy_filter_loader(monkeypatch)
+    download_config = Mock()
+    monkeypatch.setattr(semantic_backend, "hf_hub_download", download_config)
+
+    backend = semantic_backend.load_semantic_backend()
+
+    assert backend.name == "openai_privacy_filter"
+    assert backend.model == "openai/privacy-filter"
+    load.assert_called_once_with("openai/privacy-filter")
+    download_config.assert_not_called()
 
 
 def test_selected_backend_loads_once(monkeypatch):
@@ -95,6 +138,49 @@ def test_valid_local_model_is_resolved_and_loaded(monkeypatch, tmp_path):
 
     assert backend.model == str(model_path.resolve())
     load.assert_called_once_with(str(model_path.resolve()))
+
+
+def test_valid_local_privacy_filter_model_is_resolved_and_loaded(monkeypatch, tmp_path):
+    model_path = _valid_local_privacy_filter_model(tmp_path / "privacy-filter")
+    monkeypatch.setenv("DETECTOR_BACKEND", "openai_privacy_filter")
+    monkeypatch.setenv("DETECTOR_MODEL", str(model_path))
+    load = _mock_privacy_filter_loader(monkeypatch)
+
+    backend = semantic_backend.load_semantic_backend()
+
+    assert backend.model == str(model_path.resolve())
+    load.assert_called_once_with(str(model_path.resolve()))
+
+
+def test_local_privacy_filter_model_requires_weights(monkeypatch, tmp_path):
+    model_path = tmp_path / "incomplete-privacy-filter"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(json.dumps({"id2label": _privacy_filter_id2label()}))
+    monkeypatch.setenv("DETECTOR_BACKEND", "openai_privacy_filter")
+    monkeypatch.setenv("DETECTOR_MODEL", str(model_path))
+    load = _mock_privacy_filter_loader(monkeypatch)
+
+    with pytest.raises(ValueError, match=r"missing model\.safetensors"):
+        semantic_backend.load_semantic_backend()
+
+    load.assert_not_called()
+
+
+def test_local_privacy_filter_model_rejects_incompatible_labels(monkeypatch, tmp_path):
+    model_path = tmp_path / "generic-ner"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(
+        json.dumps({"id2label": {"0": "O", "1": "B-PER", "2": "I-PER"}})
+    )
+    (model_path / "model.safetensors").touch()
+    monkeypatch.setenv("DETECTOR_BACKEND", "openai_privacy_filter")
+    monkeypatch.setenv("DETECTOR_MODEL", str(model_path))
+    load = _mock_privacy_filter_loader(monkeypatch)
+
+    with pytest.raises(ValueError, match="not a Privacy Filter-compatible checkpoint"):
+        semantic_backend.load_semantic_backend()
+
+    load.assert_not_called()
 
 
 def test_existing_relative_model_directory_shadows_hub_id(monkeypatch, tmp_path):
@@ -205,6 +291,39 @@ def test_custom_hugging_face_model_is_validated_and_loaded(monkeypatch, tmp_path
 
     download_config.assert_called_once_with("org/custom-gliner", "gliner_config.json")
     load.assert_called_once_with("org/custom-gliner")
+
+
+def test_custom_privacy_filter_hugging_face_model_is_validated(monkeypatch, tmp_path):
+    config = tmp_path / "config.json"
+    config.write_text(json.dumps({"id2label": _privacy_filter_id2label()}))
+    monkeypatch.setenv("DETECTOR_BACKEND", "openai_privacy_filter")
+    monkeypatch.setenv("DETECTOR_MODEL", "org/custom-privacy-filter")
+    load = _mock_privacy_filter_loader(monkeypatch)
+    download_config = Mock(return_value=str(config))
+    monkeypatch.setattr(semantic_backend, "hf_hub_download", download_config)
+
+    semantic_backend.load_semantic_backend()
+
+    download_config.assert_called_once_with("org/custom-privacy-filter", "config.json")
+    load.assert_called_once_with("org/custom-privacy-filter")
+
+
+def test_remote_privacy_filter_model_rejects_incompatible_labels(monkeypatch, tmp_path):
+    config = tmp_path / "config.json"
+    config.write_text(json.dumps({"id2label": {"0": "O", "1": "B-PER", "2": "I-PER"}}))
+    monkeypatch.setenv("DETECTOR_BACKEND", "openai_privacy_filter")
+    monkeypatch.setenv("DETECTOR_MODEL", "org/generic-ner")
+    load = _mock_privacy_filter_loader(monkeypatch)
+    monkeypatch.setattr(
+        semantic_backend,
+        "hf_hub_download",
+        Mock(return_value=str(config)),
+    )
+
+    with pytest.raises(ValueError, match="not a Privacy Filter-compatible checkpoint"):
+        semantic_backend.load_semantic_backend()
+
+    load.assert_not_called()
 
 
 def test_non_gliner_hugging_face_model_fails_before_loading(monkeypatch):
@@ -331,6 +450,18 @@ def test_backend_info_reports_loaded_identity(monkeypatch):
     }
 
 
+def test_backend_info_reports_openai_privacy_filter_identity(monkeypatch):
+    monkeypatch.setenv("DETECTOR_BACKEND", "openai_privacy_filter")
+    _mock_privacy_filter_loader(monkeypatch)
+
+    semantic_backend.load_semantic_backend()
+
+    assert semantic_backend.backend_info() == {
+        "backend": "openai_privacy_filter",
+        "model": "openai/privacy-filter",
+    }
+
+
 def test_detect_semantic_uses_loaded_backend(monkeypatch):
     _mock_gliner_loader(monkeypatch)
     expected = [Span(PERSON, 0, 5, 0.9)]
@@ -350,6 +481,23 @@ def test_gliner_load_failure_includes_backend_and_model(monkeypatch):
         match=(
             "Failed to load semantic backend 'gliner' with model "
             "'urchade/gliner_multi_pii-v1': OSError: weights are unreadable"
+        ),
+    ):
+        semantic_backend.load_semantic_backend()
+
+    assert semantic_backend.backend_info() == {}
+
+
+def test_privacy_filter_load_failure_includes_backend_and_model(monkeypatch):
+    monkeypatch.setenv("DETECTOR_BACKEND", "openai_privacy_filter")
+    load = Mock(side_effect=ValueError("incompatible labels"))
+    monkeypatch.setattr(semantic_backend.openai_privacy_filter_layer, "load_model", load)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Failed to load semantic backend 'openai_privacy_filter' with model "
+            "'openai/privacy-filter': ValueError: incompatible labels"
         ),
     ):
         semantic_backend.load_semantic_backend()

--- a/detector/tests/test_semantic_backend.py
+++ b/detector/tests/test_semantic_backend.py
@@ -13,6 +13,7 @@ from huggingface_hub.errors import (
 
 import detector.semantic_backend as semantic_backend
 from detector.entities import PERSON, Span
+from detector.openai_privacy_filter_labels import REQUIRED_LABELS
 
 
 @pytest.fixture(autouse=True)
@@ -45,11 +46,7 @@ def _valid_local_model(path):
 def _privacy_filter_id2label():
     labels = [
         "O",
-        *[
-            f"{boundary}-{label}"
-            for label in sorted(semantic_backend.openai_privacy_filter_layer._REQUIRED_LABELS)
-            for boundary in "BIES"
-        ],
+        *[f"{boundary}-{label}" for label in sorted(REQUIRED_LABELS) for boundary in "BIES"],
     ]
     return dict(enumerate(labels))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,19 @@ services:
       dockerfile: docker/Dockerfile
     ports:
       - "${PASTEGUARD_PORT:-3000}:3000"
+    environment:
+      DETECTOR_BACKEND: ${DETECTOR_BACKEND:-gliner}
+      DETECTOR_MODEL: ${DETECTOR_MODEL:-}
+      HF_HUB_OFFLINE: ${HF_HUB_OFFLINE:-1}
+      TRANSFORMERS_OFFLINE: ${TRANSFORMERS_OFFLINE:-1}
+      PASTEGUARD_STARTUP_TIMEOUT: ${PASTEGUARD_STARTUP_TIMEOUT:-1800}
     env_file:
       - path: .env
         required: false
     volumes:
       - ./config.yaml:/pasteguard/config.yaml:ro
       - ./data:/pasteguard/data
+      - pasteguard-models:/opt/models
     restart: unless-stopped
 
   # Development only: the PII detector on its own, for `bun run dev`.
@@ -37,6 +44,19 @@ services:
       context: .
       dockerfile: docker/Dockerfile
       target: detector
+    environment:
+      DETECTOR_BACKEND: ${DETECTOR_BACKEND:-gliner}
+      DETECTOR_MODEL: ${DETECTOR_MODEL:-}
+      HF_HUB_OFFLINE: ${HF_HUB_OFFLINE:-1}
+      TRANSFORMERS_OFFLINE: ${TRANSFORMERS_OFFLINE:-1}
     ports:
       - "${PASTEGUARD_DETECTOR_PORT:-5002}:5002"
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - pasteguard-models:/opt/models
     restart: unless-stopped
+
+volumes:
+  pasteguard-models:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,11 +59,10 @@ RUN pip install --no-cache-dir supervisor==4.3.0 /srv/detector \
     && pip check \
     && pip uninstall -y pip
 
-ENV DETECTOR_MODEL=urchade/gliner_multi_pii-v1
 ENV HF_HOME=/opt/models
 RUN --mount=type=cache,target=/tmp/huggingface \
     ok=""; for i in 1 2 3; do \
-        HF_HOME=/tmp/huggingface python -c "import os; from gliner import GLiNER; GLiNER.from_pretrained(os.environ['DETECTOR_MODEL'])" && { ok=1; break; }; \
+        HF_HOME=/tmp/huggingface python -c "from detector.gliner_layer import DEFAULT_MODEL; from gliner import GLiNER; GLiNER.from_pretrained(DEFAULT_MODEL)" && { ok=1; break; }; \
         echo "model fetch attempt $i failed; retrying in 10s"; sleep 10; \
     done; \
     [ -n "$ok" ] \
@@ -82,14 +81,17 @@ COPY --from=detector-builder --chown=65532:65532 /opt/models /opt/models
 COPY --from=detector-builder --chown=65532:65532 /tmp/empty-data /pasteguard/data
 
 ENV PATH="/opt/venv/bin:${PATH}"
-ENV DETECTOR_MODEL=urchade/gliner_multi_pii-v1
+ENV DETECTOR_BACKEND=gliner
 ENV HF_HOME=/opt/models
 ENV HF_HUB_OFFLINE=1
 ENV TRANSFORMERS_OFFLINE=1
 ENV HOME=/home/nonroot
 
 EXPOSE 5002
-HEALTHCHECK --interval=10s --timeout=3s --start-period=40s --retries=5 \
+# A successful check ends the startup grace period immediately. The longer
+# failure grace lets an explicitly enabled first-run Hub download finish
+# without weakening steady-state health checks.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=30m --retries=5 \
     CMD ["python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:5002/health').status==200 else 1)"]
 
 USER 65532
@@ -117,10 +119,12 @@ COPY docker/supervisord.conf /etc/supervisord.conf
 
 # The proxy talks to the in-container detector.
 ENV DETECTOR_URL=http://localhost:5002
+# First-run model downloads can take several minutes.
+ENV PASTEGUARD_STARTUP_TIMEOUT=1800
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30m --retries=3 \
     CMD ["python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:3000/health').status==200 else 1)"]
 
 CMD ["/opt/venv/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/docs/concepts/pii-detection.mdx
+++ b/docs/concepts/pii-detection.mdx
@@ -4,17 +4,17 @@ description: Personal data detection via deterministic checks and a semantic bac
 ---
 
 PasteGuard detects PII with a small open-source service that pairs a
-deterministic regex/checksum layer with a semantic backend. Detection is
-**language-agnostic**: the semantic model finds names and places in
-mixed-language text — for example, an Italian name and city in a German letter —
-and structured identifiers (IBAN, credit card, email, IP) are matched by format
-or checksum, not by language.
+deterministic regex/checksum layer with a semantic backend. The default GLiNER
+backend is multilingual: it can find names and places in mixed-language text.
+Structured identifiers (IBAN, credit card, email, IP) are matched by format or
+checksum, not by language.
 
 ## How it works
 
 - **Deterministic layer** — regex candidates validated by checksum/format (`python-stdnum`, `phonenumbers`). Owns the structured identifiers; every match is validated, not guessed, and scores `1.0`.
-- **Semantic layer** — a loaded backend for names, locations, and street
-  addresses. GLiNER is currently the only enabled backend.
+- **Semantic layer** — either the default multilingual GLiNER backend for names,
+  locations, and street addresses, or the optional OpenAI Privacy Filter backend
+  for a broader, primarily English privacy taxonomy.
 
 The detector speaks the `/analyze` HTTP contract, is configured through the
 `detector_url` setting, and runs as a separate service (see
@@ -33,12 +33,21 @@ Backend selection does not change the deterministic layer or response contract.
 | `CREDIT_CARD` | 4111 1111 1111 1111 |
 | `IP_ADDRESS` | 192.168.1.1 |
 | `VAT_CODE` | EU VAT number, e.g. `DE136695976`, `IT00743110157`, `FR40303265045` |
+| `URL` | Private or account-specific URLs |
+| `DATE_TIME` | Private dates and times |
+| `ACCOUNT_NUMBER` | Account and personal identifier numbers |
+| `SECRET` | Contextually sensitive secret text |
 
-Names and locations use the multilingual model. IBAN, credit card, email, and IP work internationally. Phone numbers are `+` international-only by default; set `phone_regions` for local formats. `VAT_CODE` requires a country prefix and is validated with `python-stdnum`.
+The last four contextual types require a semantic backend that emits them, such
+as OpenAI Privacy Filter. IBAN, credit card, email, and IP work internationally.
+Phone numbers are `+` international-only by default; set `phone_regions` for
+local formats. `VAT_CODE` requires a country prefix and is validated with
+`python-stdnum`.
 
 ## Languages and phone regions
 
-Detection is multilingual and **language-agnostic**. PasteGuard does not auto-detect language.
+PasteGuard does not auto-detect language. GLiNER is the multilingual default;
+OpenAI Privacy Filter is primarily English.
 
 National-format phone numbers need country rules. Configure `phone_regions` only for regions your traffic uses.
 
@@ -54,7 +63,8 @@ pii_detection:
 
 Each backend can apply its own confidence floors. See
 [Semantic Backends](/configuration/semantic-backends) and
-[GLiNER](/configuration/gliner).
+[GLiNER](/configuration/gliner), or
+[OpenAI Privacy Filter](/configuration/openai-privacy-filter).
 
 ## Response Headers
 

--- a/docs/configuration/gliner.mdx
+++ b/docs/configuration/gliner.mdx
@@ -3,9 +3,9 @@ title: GLiNER
 description: Configure GLiNER models, checkpoints, confidence floors, and offline operation
 ---
 
-[GLiNER](https://github.com/urchade/GLiNER) is PasteGuard's default and currently
-only semantic backend. It detects `PERSON` and `LOCATION`; street addresses are
-also returned as `LOCATION`.
+[GLiNER](https://github.com/urchade/GLiNER) is PasteGuard's default semantic
+backend. It detects `PERSON` and `LOCATION`; street addresses are also returned
+as `LOCATION`.
 
 The default model is `urchade/gliner_multi_pii-v1`.
 
@@ -50,10 +50,11 @@ enable downloads on first start and persist the cache:
 docker volume create pasteguard-models
 
 docker run --rm -p 3000:3000 \
+  -e DETECTOR_BACKEND=gliner \
   -e DETECTOR_MODEL=urchade/gliner_small-v2.1 \
   -e HF_HUB_OFFLINE=0 \
   -e TRANSFORMERS_OFFLINE=0 \
-  -e PASTEGUARD_STARTUP_TIMEOUT=600 \
+  -e PASTEGUARD_STARTUP_TIMEOUT=1800 \
   -v pasteguard-models:/opt/models \
   ghcr.io/sgasser/pasteguard:latest
 ```
@@ -62,6 +63,7 @@ For a local model, mount the directory and use its container path:
 
 ```bash
 docker run --rm -p 3000:3000 \
+  -e DETECTOR_BACKEND=gliner \
   -e DETECTOR_MODEL=/models/custom-gliner \
   -v /absolute/path/to/custom-gliner:/models/custom-gliner:ro \
   ghcr.io/sgasser/pasteguard:latest
@@ -82,3 +84,5 @@ not lower, them.
 Legacy `DETECTOR_MODEL_PATH`, `DETECTOR_FLOOR_*`, and `DETECTOR_MAX_TOKENS`
 remain supported. `DETECTOR_MODEL_PATH` wins over `DETECTOR_MODEL`; `GLINER_*`
 wins over matching legacy variables.
+
+Restart the detector after changing its model or settings.

--- a/docs/configuration/openai-privacy-filter.mdx
+++ b/docs/configuration/openai-privacy-filter.mdx
@@ -69,6 +69,17 @@ checkpoint's optional `viterbi_calibration.json` automatically. BILOU, generic
 NER, incomplete checkpoints, and unsupported known-label boundaries fail during
 startup.
 
+## Inference Windows
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENAI_PRIVACY_FILTER_MAX_TOKENS` | `2048` | Maximum model tokens per inference window; must be at least `256` |
+
+Windows overlap by up to 128 tokens. PasteGuard averages duplicate token scores
+before one global Viterbi decode, so entities at window boundaries keep a
+coherent label path. Increase the limit only when the available memory and
+detector timeout can accommodate longer model passes.
+
 ## Local Checkpoint
 
 Mount a compatible Transformers checkpoint read-only:

--- a/docs/configuration/openai-privacy-filter.mdx
+++ b/docs/configuration/openai-privacy-filter.mdx
@@ -1,0 +1,96 @@
+---
+title: OpenAI Privacy Filter
+description: Configure the optional OpenAI Privacy Filter semantic backend
+---
+
+[OpenAI Privacy Filter](https://github.com/openai/privacy-filter) is an optional
+semantic backend with a broader privacy taxonomy than the default GLiNER model.
+
+## Quick Start
+
+Add these values to `.env`:
+
+```dotenv
+DETECTOR_BACKEND=openai_privacy_filter
+HF_HUB_OFFLINE=0
+TRANSFORMERS_OFFLINE=0
+```
+
+Then start or recreate PasteGuard:
+
+```bash
+docker compose up -d
+```
+
+The first start downloads `openai/privacy-filter` into the persistent
+`pasteguard-models` volume. After it succeeds, set both offline flags back to
+`1` if the deployment should run without Hugging Face access.
+
+Leave `DETECTOR_MODEL` unset to use `openai/privacy-filter`, or set it to a
+compatible Hugging Face model ID or local checkpoint.
+
+## Entity Mapping
+
+| Model category | PasteGuard entity |
+|----------------|-------------------|
+| `private_person` | `PERSON` |
+| `private_address` | `LOCATION` |
+| `private_email` | `EMAIL_ADDRESS` |
+| `private_phone` | `PHONE_NUMBER` |
+| `private_url` | `URL` |
+| `private_date` | `DATE_TIME` |
+| `account_number` | `ACCOUNT_NUMBER` |
+| `secret` | `SECRET` |
+
+The deterministic detector still handles validated credit cards, IBANs, IP
+addresses, VAT numbers, emails, and phone numbers independently.
+
+## `SECRET` vs. Secrets Shield
+
+`SECRET` is contextual model output controlled by
+`pii_detection.entities`. It is separate from the regex-based
+[Secrets Shield](/configuration/secrets-detection), which detects known
+credential formats such as API keys and private keys.
+
+Use both when you need contextual detection and deterministic credential
+matching.
+
+## Model Limitations
+
+<Warning>
+OpenAI Privacy Filter is primarily English and its predictions are
+probabilistic. Test it with your own data. GLiNER remains the multilingual
+default.
+</Warning>
+
+Compatible checkpoints must expose the eight categories above with complete
+BIO or BIOES labels. PasteGuard applies constrained Viterbi decoding and uses a
+checkpoint's optional `viterbi_calibration.json` automatically. BILOU, generic
+NER, incomplete checkpoints, and unsupported known-label boundaries fail during
+startup.
+
+## Local Checkpoint
+
+Mount a compatible Transformers checkpoint read-only:
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e DETECTOR_BACKEND=openai_privacy_filter \
+  -e DETECTOR_MODEL=/models/privacy-filter \
+  -v /absolute/path/to/privacy-filter:/models/privacy-filter:ro \
+  ghcr.io/sgasser/pasteguard:latest
+```
+
+The directory must contain `config.json`, model weights, and tokenizer files.
+
+## Verify
+
+Check that PasteGuard is ready:
+
+```bash
+curl http://localhost:3000/health
+```
+
+Restart or recreate the service after changing the backend or model. See
+[Semantic Backends](/configuration/semantic-backends) for backend selection and
+[Installation](/installation) for Docker and cache details.

--- a/docs/configuration/openai-privacy-filter.mdx
+++ b/docs/configuration/openai-privacy-filter.mdx
@@ -59,8 +59,9 @@ matching.
 
 <Warning>
 OpenAI Privacy Filter is primarily English and its predictions are
-probabilistic. Test it with your own data. GLiNER remains the multilingual
-default.
+probabilistic. It can also extend a span onto neighbouring words — in testing
+an email span reached into the word that followed it, which masks that word
+too. Test it with your own data. GLiNER remains the multilingual default.
 </Warning>
 
 Compatible checkpoints must expose the eight categories above with complete
@@ -68,6 +69,34 @@ BIO or BIOES labels. PasteGuard applies constrained Viterbi decoding and uses a
 checkpoint's optional `viterbi_calibration.json` automatically. BILOU, generic
 NER, incomplete checkpoints, and unsupported known-label boundaries fail during
 startup.
+
+## Performance and Resources
+
+The checkpoint has 1.4B parameters and loads as bfloat16, so the weights alone
+need about 3 GB of RAM — roughly seven times the default GLiNER model. On CPU,
+inference is limited by memory bandwidth rather than compute: raising Torch from
+four to eight threads changed total time by under 5% in testing. Adding CPU
+cores does not meaningfully help.
+
+Indicative cold-cache timings on CPU (Apple Silicon, bfloat16, four Torch
+threads). Treat these as an order of magnitude, not a guarantee:
+
+| Input | Tokens | Windows | Time |
+|-------|--------|---------|------|
+| 9,000 chars | ~1,900 | 1 | ~18 s |
+| 22,500 chars | ~4,800 | 3 | ~39 s |
+| 45,000 chars | ~9,600 | 5 | ~92 s |
+| 90,000 chars | ~19,200 | 10 | ~200 s |
+
+<Warning>
+The default `pii_detection.detector_timeout` is 30 seconds. On CPU, inputs past
+roughly 15,000–20,000 characters exceed it, and PasteGuard rejects the request
+rather than forwarding it unmasked. Raise `detector_timeout` for this backend,
+keep inputs short, or stay on GLiNER.
+</Warning>
+
+Repeated text is cached, so resent conversation history costs milliseconds.
+Only the first pass over new content pays the full price.
 
 ## Inference Windows
 
@@ -77,8 +106,13 @@ startup.
 
 Windows overlap by up to 128 tokens. PasteGuard averages duplicate token scores
 before one global Viterbi decode, so entities at window boundaries keep a
-coherent label path. Increase the limit only when the available memory and
-detector timeout can accommodate longer model passes.
+coherent label path.
+
+Lowering the limit reduces latency, because attention cost grows quadratically
+within a window — but it also shortens the context the model sees and drops
+detections. In one 11,000-character sample, moving from 2048 to 512 tokens cut
+inference time by about 60% and lost several spans, including a phone number and
+an account number. Treat it as a recall-versus-latency trade-off, not free speed.
 
 ## Local Checkpoint
 

--- a/docs/configuration/pii-detection.mdx
+++ b/docs/configuration/pii-detection.mdx
@@ -18,6 +18,10 @@ pii_detection:
     - IBAN_CODE
     - IP_ADDRESS
     - VAT_CODE
+    - URL
+    - DATE_TIME
+    - ACCOUNT_NUMBER
+    - SECRET
 ```
 
 ## Options
@@ -27,18 +31,22 @@ pii_detection:
 | `detector_url` | `http://localhost:5002` | Detector `/analyze` URL |
 | `detector_timeout` | `30` | Timeout in seconds for each detector `/analyze` request. Increase for very large messages; set to `0` to disable |
 | `phone_regions` | `[]` | Optional regions for national-format phone numbers |
-| `score_threshold` | `0.7` | Minimum confidence floor for the semantic labels PERSON and LOCATION (0.0-1.0). Checksum-validated identifiers always score `1.0` and are unaffected |
+| `score_threshold` | `0.7` | Minimum confidence floor passed to the semantic backend (0.0-1.0). Checksum-validated identifiers always score `1.0` and are unaffected |
 | `entities` | See below | Entity types to return |
 
 ## Detector Backend
 
 The detector combines deterministic checks with a semantic backend. GLiNER is
-currently the only backend. See [Semantic Backends](/configuration/semantic-backends)
-and [GLiNER](/configuration/gliner).
+the default; OpenAI Privacy Filter is optional. See
+[Semantic Backends](/configuration/semantic-backends),
+[GLiNER](/configuration/gliner), and
+[OpenAI Privacy Filter](/configuration/openai-privacy-filter).
 
 ## Phone Regions
 
-Detection is **multilingual and language-agnostic**. Names and places use one model. Structured identifiers use format or checksum checks.
+GLiNER detects names and places across multiple languages. OpenAI Privacy
+Filter is primarily English. Structured identifiers use language-independent
+format or checksum checks.
 
 Phone numbers are `+` international-only by default. Add `phone_regions` only when you need local formats.
 
@@ -66,29 +74,40 @@ Keep the list focused. More regions can mean more false positives on IDs and tic
 | `IBAN_CODE` | DE89 3704 0044 0532 0130 00 |
 | `IP_ADDRESS` | 192.168.1.1 |
 | `VAT_CODE` | EU VAT number, e.g. `DE136695976`, `IT00743110157`, `FR40303265045` |
+| `URL` | Private or account-specific URLs |
+| `DATE_TIME` | Private dates and times |
+| `ACCOUNT_NUMBER` | Account and personal identifier numbers |
+| `SECRET` | Contextually sensitive secret text |
 
-Names and locations are multilingual. IBAN, credit card, email, IP, and `+` phone numbers work internationally. `VAT_CODE` requires a country prefix and is validated with `python-stdnum`.
+GLiNER names and locations are multilingual. OpenAI Privacy Filter is primarily
+English and adds the contextual entity types shown above. IBAN, credit card,
+email, IP, and `+` phone numbers work internationally. `VAT_CODE` requires a
+country prefix and is validated with `python-stdnum`.
+
+`SECRET` here is semantic PII-detector output and is independent of the
+regex-based [Secrets Shield](/configuration/secrets-detection).
 
 ## Score Threshold
 
-`score_threshold` raises the confidence floor for the **tunable** semantic labels
-**PERSON** and **LOCATION** only. Higher = fewer false positives, might miss
-some PII; lower = catches more, more false positives.
+`score_threshold` is applied after the selected backend reconstructs complete
+semantic spans. Higher = fewer false positives, but might miss some PII; lower
+= catches more, with more false positives.
 
 ```yaml
 pii_detection:
   score_threshold: 0.7  # Default, good balance
   # score_threshold: 0.5  # More aggressive
-  # score_threshold: 0.9  # More conservative (PERSON/LOCATION)
+  # score_threshold: 0.9  # More conservative
 ```
 
 Checksum-validated identifiers are always reported (score `1.0`) and are never
 dropped by the threshold. Street addresses are detected by the semantic backend
 and reported as `LOCATION`.
 
-GLiNER floors are configured with `GLINER_FLOOR_PERSON`,
-`GLINER_FLOOR_LOCATION`, and `GLINER_FLOOR_ADDRESS`. See
-[GLiNER](/configuration/gliner).
+GLiNER also retains its calibrated per-label minimum floors, configured with
+`GLINER_FLOOR_PERSON`, `GLINER_FLOOR_LOCATION`, and
+`GLINER_FLOOR_ADDRESS`. OpenAI Privacy Filter applies the request threshold to
+all reconstructed supported spans.
 
 ## Allowlist
 

--- a/docs/configuration/semantic-backends.mdx
+++ b/docs/configuration/semantic-backends.mdx
@@ -7,7 +7,7 @@ PasteGuard's detector combines two independent layers:
 
 - The **deterministic layer** validates structured values such as email addresses,
   phone numbers, credit cards, IBANs, IP addresses, and VAT numbers.
-- The **semantic backend** detects names, locations, and street addresses.
+- The **semantic backend** uses context to detect less structured private data.
 
 Changing the backend does not affect deterministic detection.
 
@@ -16,13 +16,39 @@ Changing the backend does not affect deterministic detection.
 | `DETECTOR_BACKEND` | `gliner` | Semantic backend to load |
 | `DETECTOR_MODEL` | Backend default | Model identifier or local model directory |
 
-GLiNER is currently the only supported backend. Unknown backends and invalid
-models fail during startup. See [GLiNER](/configuration/gliner) for model and
-tuning options.
+| Backend | Default model | Semantic output |
+|---------|---------------|-----------------|
+| `gliner` | `urchade/gliner_multi_pii-v1` | `PERSON`, `LOCATION` (including street addresses) |
+| `openai_privacy_filter` | `openai/privacy-filter` | `PERSON`, `LOCATION`, `DATE_TIME`, `EMAIL_ADDRESS`, `PHONE_NUMBER`, `URL`, `ACCOUNT_NUMBER`, `SECRET` |
+
+GLiNER remains the default and is baked into the Docker image. OpenAI Privacy
+Filter is optional and downloads on first use unless its checkpoint is already
+cached or mounted locally. See [GLiNER](/configuration/gliner) and
+[OpenAI Privacy Filter](/configuration/openai-privacy-filter).
+
+Unknown backends, invalid model locations, incomplete checkpoints, and
+incompatible Privacy Filter label sets fail during detector startup.
+
+## Select a Backend
+
+For a local detector process:
+
+```bash
+DETECTOR_BACKEND=openai_privacy_filter \
+.venv/bin/uvicorn detector.app:app --host 0.0.0.0 --port 5002
+```
+
+Omit `DETECTOR_MODEL` to use the selected backend's default. Set it to a Hugging
+Face model ID or a valid local checkpoint directory to override that default.
+
+<Note>
+`DETECTOR_MODEL_PATH` remains a supported legacy alias and takes precedence over
+`DETECTOR_MODEL`.
+</Note>
 
 ## Verify the Backend
 
-Query the detector directly:
+When running the standalone detector, query it directly:
 
 ```bash
 curl http://localhost:5002/health

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -18,9 +18,9 @@ ghcr.io/sgasser/pasteguard
 | `latest` | Latest release |
 | `vX.Y.Z` | Pinned release version |
 
-Detection is multilingual and language-agnostic — one model finds entities
-regardless of the language the text is written in, so there are no per-language
-image variants.
+The default GLiNER backend is multilingual, so there are no per-language image
+variants. OpenAI Privacy Filter is also available in the same image as an
+optional, primarily English backend.
 
 ## Quick Start
 
@@ -52,12 +52,14 @@ mkdir -p data
 docker run -d --name pasteguard --restart unless-stopped -p 3000:3000 \
   -v ./config.yaml:/pasteguard/config.yaml:ro \
   -v ./data:/pasteguard/data \
+  -v pasteguard-models:/opt/models \
   ghcr.io/sgasser/pasteguard:latest
 ```
 
 This gives you:
 - **Custom config** — edit `config.yaml` to change detection settings
 - **Persistent logs** — request history in `data/pasteguard.db` survives restarts
+- **Persistent models** — custom Hub downloads survive container replacement
 - **Auto-restart** — the container restarts automatically
 
 Or with Docker Compose:
@@ -76,8 +78,10 @@ country prefix — see [PII Detection Config](/configuration/pii-detection).
 ## Detector Models
 
 The image includes `urchade/gliner_multi_pii-v1` and loads it offline by
-default. Custom Hugging Face and local models are documented under
-[GLiNER](/configuration/gliner).
+default. It also contains the dependencies needed to download and run
+`openai/privacy-filter`. See [Semantic Backends](/configuration/semantic-backends),
+[GLiNER](/configuration/gliner), and
+[OpenAI Privacy Filter](/configuration/openai-privacy-filter).
 
 ## Environment Variables
 
@@ -85,9 +89,15 @@ default. Custom Hugging Face and local models are documented under
 |----------|---------|-------------|
 | `DETECTOR_URL` | `http://localhost:5002` | Where the proxy reaches the detector. In the all-in-one image this is in-container and rarely changed; override it to point at an external detector. |
 | `DETECTOR_TIMEOUT` | `30` | Seconds to wait for each detector `/analyze` request when using the example config. Increase for very large messages; set to `0` to disable. |
-| `DETECTOR_BACKEND` | `gliner` | Semantic detector backend. GLiNER is currently the only supported value. |
-| `DETECTOR_MODEL` | `urchade/gliner_multi_pii-v1` | Hugging Face model ID or local model directory used by the detector. |
-| `PASTEGUARD_STARTUP_TIMEOUT` | `180` | Seconds to wait for the detector to become ready at startup |
+| `DETECTOR_BACKEND` | `gliner` | Semantic detector backend: `gliner` or `openai_privacy_filter`. |
+| `DETECTOR_MODEL` | Backend default | Hugging Face model ID or local model directory used by the detector. |
+| `HF_HUB_OFFLINE` | `1` | Set to `0` when an uncached Hub checkpoint must download. |
+| `TRANSFORMERS_OFFLINE` | `1` | Set to `0` with `HF_HUB_OFFLINE` for an uncached Transformers checkpoint. |
+| `PASTEGUARD_STARTUP_TIMEOUT` | `1800` | Seconds the all-in-one proxy waits for the detector to become ready. |
+
+The Compose file passes these settings from `.env` and persists `/opt/models`
+in a named volume. Restart or recreate the service after changing a backend or
+model.
 
 ## Next Steps
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -74,6 +74,7 @@
         "configuration/pii-detection",
         "configuration/semantic-backends",
         "configuration/gliner",
+        "configuration/openai-privacy-filter",
         "configuration/secrets-detection",
         "configuration/logging"
       ]

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -323,6 +323,60 @@ pii_detection:
     }
   });
 
+  test("enables every supported PII entity type by default", () => {
+    const path = writeConfig(`
+mode: mask
+providers:
+  openai: {}
+  anthropic: {}
+pii_detection:
+  detector_url: http://localhost:5002
+`);
+
+    try {
+      const config = loadConfig(path);
+
+      expect(config.pii_detection.entities).toEqual([
+        "PERSON",
+        "LOCATION",
+        "EMAIL_ADDRESS",
+        "PHONE_NUMBER",
+        "CREDIT_CARD",
+        "IBAN_CODE",
+        "IP_ADDRESS",
+        "VAT_CODE",
+        "URL",
+        "DATE_TIME",
+        "ACCOUNT_NUMBER",
+        "SECRET",
+      ]);
+    } finally {
+      cleanupConfig(path);
+    }
+  });
+
+  test("preserves an explicit PII entity selection", () => {
+    const path = writeConfig(`
+mode: mask
+providers:
+  openai: {}
+  anthropic: {}
+pii_detection:
+  detector_url: http://localhost:5002
+  entities:
+    - URL
+    - SECRET
+`);
+
+    try {
+      const config = loadConfig(path);
+
+      expect(config.pii_detection.entities).toEqual(["URL", "SECRET"]);
+    } finally {
+      cleanupConfig(path);
+    }
+  });
+
   test("accepts PII detector timeout override", () => {
     const path = writeConfig(`
 mode: mask

--- a/src/config.ts
+++ b/src/config.ts
@@ -251,13 +251,11 @@ const ConfigSchema = z
 export type Config = z.infer<typeof ConfigSchema>;
 export type OpenAIProviderConfig = z.infer<typeof OpenAIProviderSchema>;
 export type AnthropicProviderConfig = z.infer<typeof AnthropicProviderSchema>;
-export type CodexProviderConfig = z.infer<typeof CodexProviderSchema>;
 export type LocalProviderConfig = z.infer<typeof LocalProviderSchema>;
 export type MaskingConfig = z.infer<typeof MaskingSchema>;
 export type AllowlistPattern = z.infer<typeof AllowlistPatternSchema>;
 export type DenylistPattern = z.infer<typeof DenylistPatternSchema>;
 export type SecretsDetectionConfig = z.infer<typeof SecretsDetectionSchema>;
-export type ServerConfig = z.infer<typeof ServerSchema>;
 
 /**
  * Replaces ${VAR} and ${VAR:-default} patterns with environment variable values

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,6 +144,10 @@ const PIIDetectionSchema = z.object({
       "IBAN_CODE",
       "IP_ADDRESS",
       "VAT_CODE",
+      "URL",
+      "DATE_TIME",
+      "ACCOUNT_NUMBER",
+      "SECRET",
     ]),
   scan_roles: scanRolesField,
 });

--- a/src/masking/conflict-resolver.ts
+++ b/src/masking/conflict-resolver.ts
@@ -1,6 +1,3 @@
-// Conflict resolution based on Microsoft Presidio's logic
-// https://github.com/microsoft/presidio/blob/main/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
-
 export interface Span {
   start: number;
   end: number;

--- a/src/pii/request.ts
+++ b/src/pii/request.ts
@@ -59,10 +59,6 @@ export function maskPII<TRequest, TResponse>(
   };
 }
 
-export type { PlaceholderContext } from "../masking/context";
-export type { PIIDetectionResult, PIIEntity } from "./detect";
-export { createMaskingContext } from "./mask";
-
 /**
  * Check if the detector is healthy
  */

--- a/src/providers/openai/types.ts
+++ b/src/providers/openai/types.ts
@@ -70,7 +70,6 @@ export const OpenAIResponseSchema = z.object({
 
 // Inferred types
 export type OpenAIContentPart = z.infer<typeof OpenAIContentPartSchema>;
-export type OpenAIMessageContent = z.infer<typeof OpenAIMessageContentSchema>;
 export type OpenAIMessage = z.infer<typeof OpenAIMessageSchema>;
 export type OpenAIRequest = z.infer<typeof OpenAIRequestSchema>;
 export type OpenAIResponse = z.infer<typeof OpenAIResponseSchema>;

--- a/src/routes/api.test.ts
+++ b/src/routes/api.test.ts
@@ -231,6 +231,39 @@ describe("POST /api/mask", () => {
     expect(mockDetectPII).toHaveBeenCalled();
   });
 
+  test("masks a semantic SECRET as PII when only PII detection is selected", async () => {
+    const text = "The internal passphrase is blue-orchid.";
+    const secret = "blue-orchid";
+    const start = text.indexOf(secret);
+    mockDetectPII.mockResolvedValueOnce([
+      {
+        entity_type: "SECRET",
+        start,
+        end: start + secret.length,
+        score: 0.92,
+      },
+    ]);
+
+    const res = await app.request("/api/mask", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text,
+        detect: ["pii"],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      masked: string;
+      context: Record<string, string>;
+      entities: { type: string; placeholder: string }[];
+    };
+    expect(body.masked).toBe("The internal passphrase is [[SECRET_1]].");
+    expect(body.context["[[SECRET_1]]"]).toBe(secret);
+    expect(body.entities).toEqual([{ type: "SECRET", placeholder: "[[SECRET_1]]" }]);
+  });
+
   test("masks secrets when detected", async () => {
     // Skip PII detection
     const res = await app.request("/api/mask", {

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,3 +1,3 @@
-import type { OpenAIContentPart, OpenAIMessageContent } from "../providers/openai/types";
+import type { OpenAIContentPart } from "../providers/openai/types";
 
-export type { OpenAIContentPart, OpenAIMessageContent };
+export type { OpenAIContentPart };


### PR DESCRIPTION
Adds an optional OpenAI Privacy Filter semantic backend with validated Hub/local checkpoints, constrained BIO/BIOES Viterbi decoding, overlapping-window handling, and complete-span coalescing.

Extends the masking taxonomy with URL, DATE_TIME, ACCOUNT_NUMBER, and contextual SECRET while keeping GLiNER the multilingual default.

Updates Docker/Compose model caching and the public configuration and installation docs.

Verified with 440 Bun tests (1 skipped), 154 detector tests, TypeScript, Biome, Ruff format/lint, Pyright, pip check, both Docker targets, and live non-root/read-only checkpoint tests through standalone and all-in-one masking flows.
