### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Updates the package version to 0.9.2 for the security patch release.
The release includes #163, which blocks browser-originated requests to the OpenAI, Anthropic, and Codex proxy routes while preserving CLI, SDK, and configured provider-key fallback behavior.
This branch changes only `package.json`.
Verified with 444 passing tests (1 optional Postgres test skipped), TypeScript type checking, and Biome.
