### PR TITLE
Bump version to 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteguard",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Privacy proxy for LLMs. Masks personal data and secrets before sending to your provider.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

- bump the package version from 0.9.2 to 0.9.3
- prepare the patch release containing the verified tool-argument restoration fixes

## Included fixes

- #168 restores and safely remasks OpenAI Chat tool-call arguments
- #169 restores Anthropic tool inputs without normalizing serialized JSON
- #170 restores Responses/Codex function-call arguments while preserving stream semantics

## Validation

- each fix PR was updated onto the preceding merged `main` state and passed all required GitHub CI jobs before squash merge
- final combined `main` passed Test & Lint, Detector Lint/Types/Tests, and Docker Build Test
- local release-bump verification: 498 passed, 1 existing optional PostgreSQL skip, 0 failed
- TypeScript typecheck, benchmark typecheck, Biome, JSON parsing, and `git diff --check` passed

## Scope

This PR changes only `package.json`. Tagging, GitHub Release creation, and image publication will occur only after this PR merges with green CI.
